### PR TITLE
Implement drag highlight for Kanban cards

### DIFF
--- a/kanban/kanban_base.js
+++ b/kanban/kanban_base.js
@@ -106,12 +106,14 @@ export function enableDragAndDrop(itemsKanban) {
       draggedFromColumn = e.target.dataset.column;
       e.dataTransfer.setData('text/plain', '');
       e.dataTransfer.effectAllowed = 'move';
+      e.target.classList.add('dragging');
     });
 
-    li.addEventListener('dragend', () => {
+    li.addEventListener('dragend', e => {
       removePlaceholder();
       draggedIndex = null;
       draggedFromColumn = null;
+      e.target.classList.remove('dragging');
     });
   });
 

--- a/menu_produto.css
+++ b/menu_produto.css
@@ -2907,6 +2907,12 @@ ul#comprasList li ,
   box-shadow: 0 2px 6px rgba(0,0,0,0.3);
 }
 
+/* item sendo arrastado */
+.kanban-list li.dragging {
+  background-color: #fff59d !important; /* amarelo claro */
+  color: #333 !important;
+}
+
 
 /* ─── Placeholder de drag (pontilhado no tamanho dos cards) ─── */
 .kanban-list li.placeholder {


### PR DESCRIPTION
## Summary
- make dragged Kanban card turn yellow
- add CSS style and hook dragstart/dragend events

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684715990288832ca02449db34777ba1