### PR TITLE
Fix OMIE config fallback

### DIFF
--- a/config.server.js
+++ b/config.server.js
@@ -1,7 +1,11 @@
 // config.server.js
 module.exports = {
-  OMIE_APP_KEY:    process.env.OMIE_APP_KEY,
-  OMIE_APP_SECRET: process.env.OMIE_APP_SECRET,
+  // When running on platforms like Render the environment variables used to
+  // authenticate against the OMIE API might not be defined.  In that case we
+  // fall back to the same values shipped with the front‑end configuration so
+  // the API calls keep working.
+  OMIE_APP_KEY:    process.env.OMIE_APP_KEY    || '3917057082939',
+  OMIE_APP_SECRET: process.env.OMIE_APP_SECRET || '11e503358e3ae0bee91053faa1323629',
   GITHUB_TOKEN:    process.env.GITHUB_TOKEN,
   GITHUB_BRANCH:   process.env.GITHUB_BRANCH || 'main',
   GITHUB_OWNER:    process.env.GITHUB_OWNER   || 'qualidafromtherm2',


### PR DESCRIPTION
## Summary
- add fallback OMIE credentials in `config.server.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684abf2a0468832cbaa32fb917dbad1d