### PR TITLE
feat(compras): equivalência de unidades (UN/UND/PC…) na associação NF-e ↔ pedido

### DIFF
--- a/menu_produto.html
+++ b/menu_produto.html
@@ -12216,6 +12216,58 @@ function attachDropZone(ul) {
   const fmtMoeda = (v) => { const n = Number(v); return Number.isFinite(n) ? n.toLocaleString('pt-BR',{style:'currency',currency:'BRL'}) : '-'; };
   const fmtQtd   = (v) => { const n = Number(v); return Number.isFinite(n) ? n.toLocaleString('pt-BR',{minimumFractionDigits:2,maximumFractionDigits:4}) : '-'; };
 
+  const DICIONARIO_EQUIVALENCIA_UNIDADE_LOCALIZAR = {
+    UN: ['UN', 'UND', 'UNID', 'UNIDADE', 'UNIDAD', 'UNIT', 'PC', 'PÇ', 'PECA', 'PEÇA', 'PCS', 'PÇS', 'PECAS', 'PEÇAS'],
+    PAR: ['PAR', 'PARES', 'PR'],
+    CX: ['CX', 'CAIXA', 'CXS', 'CAIXAS'],
+    PCT: ['PCT', 'PAC', 'PACOTE', 'PACOTES', 'EMB', 'EMBALAGEM', 'EMBALAGENS'],
+    RL: ['RL', 'RLO', 'ROLO', 'ROLOS'],
+    M: ['M', 'MT', 'MTS', 'METRO', 'METROS'],
+    CM: ['CM', 'CENTIMETRO', 'CENTÍMETRO', 'CENTIMETROS', 'CENTÍMETROS'],
+    MM: ['MM', 'MILIMETRO', 'MILÍMETRO', 'MILIMETROS', 'MILÍMETROS'],
+    KG: ['KG', 'KILO', 'QUILO', 'QUILOGRAMA', 'QUILOGRAMAS'],
+    G: ['G', 'GR', 'GRAMA', 'GRAMAS'],
+    TON: ['TON', 'T', 'TONELADA', 'TONELADAS'],
+    L: ['L', 'LT', 'LTS', 'LITRO', 'LITROS'],
+    ML: ['ML', 'MILILITRO', 'MILILITROS'],
+    M2: ['M2', 'M²', 'MT2', 'METRO2', 'METRO QUADRADO', 'METROS QUADRADOS'],
+    M3: ['M3', 'M³', 'MT3', 'METRO3', 'METRO CUBICO', 'METRO CÚBICO', 'METROS CUBICOS', 'METROS CÚBICOS']
+  };
+
+  const normalizarTokenUnidadeLocalizar = (v) => String(v || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/²/g, '2')
+    .replace(/³/g, '3')
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, '');
+
+  const mapaCanonicoUnidadeLocalizar = (() => {
+    const mapa = new Map();
+    Object.entries(DICIONARIO_EQUIVALENCIA_UNIDADE_LOCALIZAR).forEach(([canonico, aliases]) => {
+      const chaveCanonica = normalizarTokenUnidadeLocalizar(canonico);
+      if (chaveCanonica) mapa.set(chaveCanonica, canonico);
+      aliases.forEach((alias) => {
+        const chaveAlias = normalizarTokenUnidadeLocalizar(alias);
+        if (chaveAlias) mapa.set(chaveAlias, canonico);
+      });
+    });
+    return mapa;
+  })();
+
+  const unidadeCanonicaLocalizar = (v) => {
+    const token = normalizarTokenUnidadeLocalizar(v);
+    if (!token) return '';
+    return mapaCanonicoUnidadeLocalizar.get(token) || token;
+  };
+
+  const unidadesEquivalentesLocalizar = (a, b) => {
+    const ua = unidadeCanonicaLocalizar(a);
+    const ub = unidadeCanonicaLocalizar(b);
+    if (!ua || !ub) return false;
+    return ua === ub;
+  };
+
   // ── Score local determinístico ────────────────────────────────
   // Retorna 0-100. Usado para ordenar automaticamente sem depender da IA.
 
@@ -12248,6 +12300,7 @@ function attachDropZone(ul) {
     let melhorDesc = 0;
     let melhorQtd  = 0;
     let melhorVal  = 0;
+    let melhorUnid = 0;
 
     // Para cada item da NF-e, procura o item do pedido com maior match
     itensNfe.forEach(nfeItem => {
@@ -12256,7 +12309,7 @@ function attachDropZone(ul) {
       const qtdNfe    = Math.abs(Number(nfeItem.qtd) || 0);
       const totalNfe  = Number(nfeItem.vlr_item) || 0;   // valor total da linha NF-e
 
-      let bestForThisItem = { desc: 0, qtd: 0, val: 0 };
+      let bestForThisItem = { desc: 0, qtd: 0, val: 0, unid: 0 };
       itensPed.forEach(pedItem => {
         const tokPed = tokenizar(pedItem.produto_descricao);
         if (!tokPed.length) return;
@@ -12274,6 +12327,12 @@ function attachDropZone(ul) {
           ? Math.max(0, Math.round(100 - Math.abs(qtdNfe - qtdPed) / Math.max(qtdNfe, qtdPed) * 100))
           : 50;
 
+        const unidadeNfe = String(nfeItem.unidade || '').trim();
+        const unidadePed = String(pedItem.unidade || '').trim();
+        const uScore = (unidadeNfe && unidadePed)
+          ? (unidadesEquivalentesLocalizar(unidadeNfe, unidadePed) ? 100 : 0)
+          : 50;
+
         // Score de VALOR TOTAL (muito mais confiável que unitário — evita o problema
         // de "1 pacote com 4 peças" vs "4 peças individuais")
         const totalPed = Number(pedItem.valor_item) || 0;
@@ -12286,15 +12345,16 @@ function attachDropZone(ul) {
           tScore = 50;  // não temos valor para comparar → neutro
         }
 
-        const combinado = dScore * 0.40 + tScore * 0.35 + qScore * 0.20;
-        const bestComb  = bestForThisItem.desc * 0.40 + bestForThisItem.val * 0.35 + bestForThisItem.qtd * 0.20;
+        const combinado = dScore * 0.38 + tScore * 0.30 + qScore * 0.20 + uScore * 0.12;
+        const bestComb  = bestForThisItem.desc * 0.38 + bestForThisItem.val * 0.30 + bestForThisItem.qtd * 0.20 + bestForThisItem.unid * 0.12;
         if (combinado > bestComb) {
-          bestForThisItem = { desc: dScore, qtd: qScore, val: tScore };
+          bestForThisItem = { desc: dScore, qtd: qScore, val: tScore, unid: uScore };
         }
       });
       if (bestForThisItem.desc > melhorDesc) melhorDesc = bestForThisItem.desc;
       if (bestForThisItem.qtd > melhorQtd)  melhorQtd  = bestForThisItem.qtd;
       if (bestForThisItem.val > melhorVal)  melhorVal  = bestForThisItem.val;
+      if (bestForThisItem.unid > melhorUnid) melhorUnid = bestForThisItem.unid;
     });
 
     // Score de número de itens: NF-e com 1 item deve preferir pedido com 1 item.
@@ -12315,8 +12375,8 @@ function attachDropZone(ul) {
       fScore = setAll.size > 0 ? Math.round((inter / setAll.size) * 100) : 0;
     }
 
-    // Pesos: descrição 35%, valor total 30%, nº itens 20%, qtd 10%, fornecedor 5%
-    return Math.round(melhorDesc * 0.35 + melhorVal * 0.30 + nScore * 0.20 + melhorQtd * 0.10 + fScore * 0.05);
+    // Pesos: descrição 32%, valor total 28%, nº itens 18%, qtd 10%, unidade 7%, fornecedor 5%
+    return Math.round(melhorDesc * 0.32 + melhorVal * 0.28 + nScore * 0.18 + melhorQtd * 0.10 + melhorUnid * 0.07 + fScore * 0.05);
   };
 
   const scoreBadgeLocal = (s) => {

--- a/menu_produto.js
+++ b/menu_produto.js
@@ -46199,6 +46199,63 @@ function obterUnidadePedidoPreviewAssociacao(item) {
   return String(encontrado?.unidade || '-').trim() || '-';
 }
 
+const DICIONARIO_EQUIVALENCIA_UNIDADE_PREVIEW = {
+  UN: ['UN', 'UND', 'UNID', 'UNIDADE', 'UNIDAD', 'UNIT', 'PC', 'PÇ', 'PECA', 'PEÇA', 'PCS', 'PÇS', 'PECAS', 'PEÇAS'],
+  PAR: ['PAR', 'PARES', 'PR'],
+  CX: ['CX', 'CAIXA', 'CXS', 'CAIXAS'],
+  PCT: ['PCT', 'PAC', 'PACOTE', 'PACOTES', 'EMB', 'EMBALAGEM', 'EMBALAGENS'],
+  RL: ['RL', 'RLO', 'ROLO', 'ROLOS'],
+  M: ['M', 'MT', 'MTS', 'METRO', 'METROS'],
+  CM: ['CM', 'CENTIMETRO', 'CENTÍMETRO', 'CENTIMETROS', 'CENTÍMETROS'],
+  MM: ['MM', 'MILIMETRO', 'MILÍMETRO', 'MILIMETROS', 'MILÍMETROS'],
+  KG: ['KG', 'KILO', 'QUILO', 'QUILOGRAMA', 'QUILOGRAMAS'],
+  G: ['G', 'GR', 'GRAMA', 'GRAMAS'],
+  TON: ['TON', 'T', 'TONELADA', 'TONELADAS'],
+  L: ['L', 'LT', 'LTS', 'LITRO', 'LITROS'],
+  ML: ['ML', 'MILILITRO', 'MILILITROS'],
+  M2: ['M2', 'M²', 'MT2', 'METRO2', 'METRO QUADRADO', 'METROS QUADRADOS'],
+  M3: ['M3', 'M³', 'MT3', 'METRO3', 'METRO CUBICO', 'METRO CÚBICO', 'METROS CUBICOS', 'METROS CÚBICOS']
+};
+
+function normalizarTokenUnidadePreview(valor) {
+  return String(valor || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/²/g, '2')
+    .replace(/³/g, '3')
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, '');
+}
+
+const MAPA_CANONICO_UNIDADE_PREVIEW = (() => {
+  const mapa = new Map();
+
+  Object.entries(DICIONARIO_EQUIVALENCIA_UNIDADE_PREVIEW).forEach(([canonico, aliases]) => {
+    const chaveCanonica = normalizarTokenUnidadePreview(canonico);
+    if (chaveCanonica) mapa.set(chaveCanonica, canonico);
+
+    aliases.forEach((alias) => {
+      const chaveAlias = normalizarTokenUnidadePreview(alias);
+      if (chaveAlias) mapa.set(chaveAlias, canonico);
+    });
+  });
+
+  return mapa;
+})();
+
+function unidadeCanonicaPreview(valor) {
+  const token = normalizarTokenUnidadePreview(valor);
+  if (!token) return '';
+  return MAPA_CANONICO_UNIDADE_PREVIEW.get(token) || token;
+}
+
+function unidadesEquivalentesPreview(unidadeA, unidadeB) {
+  const canonicaA = unidadeCanonicaPreview(unidadeA);
+  const canonicaB = unidadeCanonicaPreview(unidadeB);
+  if (!canonicaA || !canonicaB) return false;
+  return canonicaA === canonicaB;
+}
+
 function snapshotEdicoesQtdUnidAssociacaoNfe() {
   const previewConteudo = document.getElementById('modalAssociarPedidoNfePreviewConteudo');
   if (!previewConteudo) return;
@@ -46357,10 +46414,11 @@ function renderPreviewAssociacaoPedidoNfe(preview) {
     return String(item?.nf_qtde ?? '').trim() !== String(item?.pedido_qtde ?? '').trim();
   };
   const compararUnidadePreview = (item, unidadePedido) => {
-    const nfUnidade = normalizarTextoRecebimento(item?.nf_unidade || '');
-    const pedidoUnidade = normalizarTextoRecebimento(unidadePedido || '');
+    const nfUnidade = String(item?.nf_unidade || '').trim();
+    const pedidoUnidade = String(unidadePedido || '').trim();
     if (!nfUnidade && !pedidoUnidade) return false;
-    return nfUnidade !== pedidoUnidade;
+    if (!nfUnidade || !pedidoUnidade) return true;
+    return !unidadesEquivalentesPreview(nfUnidade, pedidoUnidade);
   };
 
   const itensComMatch = itens.filter((item) => !!item?.pedido_item_encontrado).length;

--- a/server.js
+++ b/server.js
@@ -27838,8 +27838,9 @@ app.post('/api/compras/ranking-pedidos-nfe', async (req, res) => {
 REGRAS DE CLASSIFICAÇÃO (em ordem de importância):
 1. DESCRIÇÃO DO PRODUTO (peso 60%): Pedidos com descrição igual ou muito semelhante aos itens da NF-e devem ter score altíssimo. Correspondência parcial de palavras (ex: "BORBOLETA ZAMAC") ainda conta bastante.
 2. QUANTIDADE (peso 20%): Se a quantidade dos itens do pedido for igual ou muito próxima à da NF-e, aumente o score. Divergência grande reduz o score.
-3. VALOR UNITÁRIO (peso 15%): Se o valor unitário do item do pedido for próximo ao valor unitário da NF-e (vlr_item ÷ qtd), aumente o score.
-4. FORNECEDOR / DATA (peso 5%): Pedidos do mesmo fornecedor ou data próxima são leve tiebreaker.
+3. UNIDADE DE MEDIDA (peso 15%): Considere equivalentes: UN/UND/UNID/UNIDADE/PC/PECA; PAR/PARES/PR; CX/CAIXA; PCT/PAC/PACOTE/EMB/EMBALAGEM; RL/ROLO; M/MT/MTS/METRO; CM/CENTIMETRO; MM/MILIMETRO; KG/KILO/QUILO; G/GR/GRAMA; TON/T/TONELADA; L/LT/LITRO; ML/MILILITRO; M2/M²/MT2/METRO QUADRADO; M3/M³/MT3/METRO CUBICO. Equivalência deve aumentar score; unidade incompatível deve reduzir score.
+4. VALOR UNITÁRIO (peso 10%): Se o valor unitário do item do pedido for próximo ao valor unitário da NF-e (vlr_item ÷ qtd), aumente o score.
+5. FORNECEDOR / DATA (peso 5%): Pedidos do mesmo fornecedor ou data próxima são leve tiebreaker.
 IGNORE: categoria genérica, ordem de listagem, número do pedido.
 
 NF-e:
@@ -29375,6 +29376,64 @@ function tokenizarTextoAssociacaoNfePedido(valor) {
   )];
 }
 
+const DICIONARIO_EQUIVALENCIA_UNIDADE_MATCH = {
+  UN: ['UN', 'UND', 'UNID', 'UNIDADE', 'UNIDAD', 'UNIT', 'PC', 'PÇ', 'PECA', 'PEÇA', 'PCS', 'PÇS', 'PECAS', 'PEÇAS'],
+  PAR: ['PAR', 'PARES', 'PR'],
+  CX: ['CX', 'CAIXA', 'CXS', 'CAIXAS'],
+  PCT: ['PCT', 'PAC', 'PACOTE', 'PACOTES', 'EMB', 'EMBALAGEM', 'EMBALAGENS'],
+  RL: ['RL', 'RLO', 'ROLO', 'ROLOS'],
+  M: ['M', 'MT', 'MTS', 'METRO', 'METROS'],
+  CM: ['CM', 'CENTIMETRO', 'CENTÍMETRO', 'CENTIMETROS', 'CENTÍMETROS'],
+  MM: ['MM', 'MILIMETRO', 'MILÍMETRO', 'MILIMETROS', 'MILÍMETROS'],
+  KG: ['KG', 'KILO', 'QUILO', 'QUILOGRAMA', 'QUILOGRAMAS'],
+  G: ['G', 'GR', 'GRAMA', 'GRAMAS'],
+  TON: ['TON', 'T', 'TONELADA', 'TONELADAS'],
+  L: ['L', 'LT', 'LTS', 'LITRO', 'LITROS'],
+  ML: ['ML', 'MILILITRO', 'MILILITROS'],
+  M2: ['M2', 'M²', 'MT2', 'METRO2', 'METRO QUADRADO', 'METROS QUADRADOS'],
+  M3: ['M3', 'M³', 'MT3', 'METRO3', 'METRO CUBICO', 'METRO CÚBICO', 'METROS CUBICOS', 'METROS CÚBICOS']
+};
+
+function normalizarTokenUnidadeMatch(valor) {
+  return String(valor || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/²/g, '2')
+    .replace(/³/g, '3')
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, '');
+}
+
+const MAPA_CANONICO_UNIDADE_MATCH = (() => {
+  const mapa = new Map();
+
+  Object.entries(DICIONARIO_EQUIVALENCIA_UNIDADE_MATCH).forEach(([canonico, alias]) => {
+    const chaveCanonica = normalizarTokenUnidadeMatch(canonico);
+    if (chaveCanonica) mapa.set(chaveCanonica, canonico);
+
+    alias.forEach((itemAlias) => {
+      const chaveAlias = normalizarTokenUnidadeMatch(itemAlias);
+      if (chaveAlias) mapa.set(chaveAlias, canonico);
+    });
+  });
+
+  return mapa;
+})();
+
+function unidadeCanonicaMatch(valor) {
+  const token = normalizarTokenUnidadeMatch(valor);
+  if (!token) return '';
+  return MAPA_CANONICO_UNIDADE_MATCH.get(token) || token;
+}
+
+function unidadesEquivalentesMatch(unidadeA, unidadeB) {
+  const canonicaA = unidadeCanonicaMatch(unidadeA);
+  const canonicaB = unidadeCanonicaMatch(unidadeB);
+
+  if (!canonicaA || !canonicaB) return false;
+  return canonicaA === canonicaB;
+}
+
 function calcularScoreAssociacaoNfePedido(itemReceb, itemPedido) {
   const itensCabec = itemReceb?.itensCabec || {};
   const codigoRecBruto = String(itensCabec?.cCodigoProduto || '').trim();
@@ -29425,6 +29484,16 @@ function calcularScoreAssociacaoNfePedido(itemReceb, itemPedido) {
       const proporcao = Math.max(qtdRec, qtdPedido) / Math.min(qtdRec, qtdPedido);
       if (proporcao <= 1.25) score += 18;
       else if (proporcao <= 2) score += 8;
+    }
+  }
+
+  const unidadeRec = String(itensCabec?.cUnidadeNFe || itensCabec?.cUnidadeNfe || '').trim();
+  const unidadePedido = String(itemPedido?.c_unidade || '').trim();
+  if (unidadeRec && unidadePedido) {
+    if (unidadesEquivalentesMatch(unidadeRec, unidadePedido)) {
+      score += 55;
+    } else {
+      score -= 20;
     }
   }
 


### PR DESCRIPTION
## Resumo
Adiciona dicionário canônico de unidades de medida e usa essa equivalência tanto no score automático de match (em `menu_produto.html`) quanto na comparação visual de unidades da prévia de associação (em `menu_produto.js`). Backend (`server.js`) recebe ajustes correspondentes.

## Escopo
- `menu_produto.html`: dicionário `DICIONARIO_EQUIVALENCIA_UNIDADE_LOCALIZAR` + score com peso de unidade (12% no item / 7% no agregado).
- `menu_produto.js`: dicionário `DICIONARIO_EQUIVALENCIA_UNIDADE_PREVIEW` + `unidadesEquivalentesPreview` para destacar divergência apenas quando realmente diferentes.
- `server.js`: ajustes relacionados (ver diff).

## Validação local
- `pm2 flush && pm2 restart intranet_api` aplicado.