### PR TITLE
feat(compras): adicionar categoria embalagem produtos

### DIFF
--- a/menu_produto.js
+++ b/menu_produto.js
@@ -26494,11 +26494,40 @@ window.categoriasPorDepartamento = {
     'Investimento na produção',
     'Manutenção',
     'Maquinas e equipamentos',
+    'Embalagem dos produtos',
     'Materia prima',
     'Outros',
     'P&D'
   ]
 };
+
+function normalizarCategoriaOperacionalCompra(valor) {
+  return String(valor || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .toLowerCase();
+}
+
+function obterCategoriaCompraOmiePorCentroCusto(centroCusto) {
+  const categoria = normalizarCategoriaOperacionalCompra(centroCusto);
+
+  if (categoria === 'materia prima') {
+    return {
+      codigo: '2.01.03',
+      nome: '2.01.03 - Materia Prima Nacional'
+    };
+  }
+
+  if (categoria === 'embalagem dos produtos') {
+    return {
+      codigo: '2.01.93',
+      nome: '2.01.93 - Embalagem Dos Produtos'
+    };
+  }
+
+  return null;
+}
 
 // Carrega opções de departamentos, centros de custo e usuários
 async function carregarDepartamentosECentros() {
@@ -27305,7 +27334,7 @@ async function adicionarItemCarrinho(ev) {
   const responsavelCompra = (document.getElementById('modalComprasResponsavelCompra')?.value || '').trim();
   const retornoCotacao = (document.getElementById('modalComprasRetornoCotacao')?.value || '').trim();
   let categoriaCompra = (document.getElementById('modalComprasCategoriaCompra')?.value || '').trim();
-  const categoriaCompraTexto = document.getElementById('modalComprasCategoriaCompra')?.selectedOptions[0]?.text || '';
+  let categoriaCompraTexto = document.getElementById('modalComprasCategoriaCompra')?.selectedOptions[0]?.text || '';
   const codigoProdutoOmie = document.getElementById('modalComprasCodigoProdutoOmie')?.value || null;
   const requisicaoDireta = document.getElementById('modalComprasRequisicaoDireta')?.checked || false;
   const statusPedido = (document.getElementById('modalComprasStatus')?.value || 'aguardando aprovação da requisição').trim();
@@ -27370,9 +27399,11 @@ async function adicionarItemCarrinho(ev) {
   if (!categoriaCompra) {
     categoriaCompra = categoriaPadraoCodigo;
   }
-  // Se Categoria for "Materia prima", força código de categoria Omie 2.01.03
-  if ((centroCusto || '').toLowerCase() === 'materia prima') {
-    categoriaCompra = '2.01.03';
+  // Categorias operacionais especificas devem gravar o codigo correto da Omie.
+  const categoriaOperacionalOmie = obterCategoriaCompraOmiePorCentroCusto(centroCusto);
+  if (categoriaOperacionalOmie) {
+    categoriaCompra = categoriaOperacionalOmie.codigo;
+    categoriaCompraTexto = categoriaOperacionalOmie.nome;
   }
   
   // Busca codigo_produto da tabela produtos_omie usando o codigo do produto
@@ -39112,6 +39143,7 @@ window.categoriasPorDepartamento = {
     'Investimento na produção',
     'Manutenção',
     'Maquinas e equipamentos',
+    'Embalagem dos produtos',
     'Materia prima',
     'Outros',
     'P&D'
@@ -39549,10 +39581,11 @@ async function selecionarProdutoCatalogo(codigo, descricao, event = null) {
       ? `${cat.codigo} - ${cat.descricao}`
       : categoriaCompraTexto || `${categoriaPadraoCodigo} - Outros Materiais`;
   }
-  // Se Categoria for "Materia prima", força código de categoria Omie 2.01.03
-  if ((centroCusto || '').toLowerCase() === 'materia prima') {
-    categoriaCompra = '2.01.03';
-    categoriaCompraTexto = '2.01.03 - Matérias-Primas';
+  // Categorias operacionais especificas devem gravar o codigo correto da Omie.
+  const categoriaOperacionalOmie = obterCategoriaCompraOmiePorCentroCusto(centroCusto);
+  if (categoriaOperacionalOmie) {
+    categoriaCompra = categoriaOperacionalOmie.codigo;
+    categoriaCompraTexto = categoriaOperacionalOmie.nome;
   }
   
   console.log('[Catálogo] Categoria selecionada - Código:', categoriaCompra, 'Descrição:', categoriaCompraTexto);
@@ -39828,9 +39861,10 @@ async function adicionarProdutoNaoCadastradoAoCarrinho(event) {
   if (!categoriaCompra) {
     categoriaCompra = categoriaPadraoCodigo;
   }
-  // Se Categoria for "Materia prima", força código de categoria Omie 2.01.03
-  if ((centroCusto || '').toLowerCase() === 'materia prima') {
-    categoriaCompra = '2.01.03';
+  // Categorias operacionais especificas devem gravar o codigo correto da Omie.
+  const categoriaOperacionalOmie = obterCategoriaCompraOmiePorCentroCusto(centroCusto);
+  if (categoriaOperacionalOmie) {
+    categoriaCompra = categoriaOperacionalOmie.codigo;
   }
   
   console.log('[Catálogo] Descrição (keywords):', descricao);
@@ -39982,7 +40016,7 @@ async function adicionarProdutoNaoCadastradoAoCarrinho(event) {
       departamento: departamento,
       centro_custo: centroCusto,
       categoria_compra_codigo: categoriaCompra,
-      categoria_compra_nome: categoriaCompra === '2.01.03' ? 'Matérias-Primas' : (categoriaCompra === '2.14.94' ? 'Outros Materiais' : ''),
+      categoria_compra_nome: categoriaOperacionalOmie?.nome || (categoriaCompra === '2.14.94' ? 'Outros Materiais' : ''),
       objetivo_compra: objetivoCompra,
       retorno_cotacao: retornoCotacao,
       tipo_retorno_solicitado: retornoCotacao,
@@ -46093,11 +46127,29 @@ async function carregarSeletorCategoriasAssociarNfe(categoriaAtualCodigo, catego
   picker.style.display = 'flex';
 
   try {
-    const resp = await fetch('/api/compras/categorias-ativas', { credentials: 'include' });
+    // Usa a mesma lista curta do fluxo de compras, não o plano de contas inteiro.
+    const resp = await fetch('/api/compras/categorias', { credentials: 'include' });
     const data = await resp.json().catch(() => ({}));
     if (!resp.ok || !data?.ok) throw new Error(data?.error || 'Falha ao carregar categorias');
 
     const categorias = Array.isArray(data.categorias) ? data.categorias : [];
+    const categoriasOrdenadas = [...categorias].sort((a, b) => {
+      const da = String(a?.descricao || a?.codigo || '');
+      const db = String(b?.descricao || b?.codigo || '');
+      return da.localeCompare(db, 'pt-BR', { sensitivity: 'base' });
+    });
+
+    select.innerHTML = '<option value="">-- Selecione uma categoria --</option>';
+    categoriasOrdenadas.forEach(cat => {
+      const opt = document.createElement('option');
+      opt.value = cat.codigo;
+      opt.textContent = `${cat.codigo} - ${cat.descricao || cat.codigo}`;
+      select.appendChild(opt);
+    });
+    if (categoriaAtualCodigo && categoriasOrdenadas.some(cat => String(cat.codigo) === String(categoriaAtualCodigo))) {
+      select.value = categoriaAtualCodigo;
+    }
+    return;
 
     // Separa categorias-pai (sem categoria_superior ou categoria_superior que não existe como codigo)
     const codigosExistentes = new Set(categorias.map(c => c.codigo));

--- a/server.js
+++ b/server.js
@@ -30161,9 +30161,12 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
     }
 
     // ─── Passo 1: associação do pedido (PRIMEIRO, pois pode resetar dados financeiros) ───
+    // Se houver troca de categoria, ela precisa ir junto com a associação.
+    // A Omie pode validar a categoria antiga já no vínculo do pedido antes do Passo 2.
     const payloadAlterar = {
       ide: { nIdReceb: Number(plano.n_id_receb) },
-      itensRecebimentoEditar: itensParaEnviar
+      itensRecebimentoEditar: itensParaEnviar,
+      ...(novaCategoriaCompra && infoAdicionaisParaEnviar ? { infoAdicionais: infoAdicionaisParaEnviar } : {})
     };
 
     console.log('[Compras/NFeAssociarPedido] ===== PASSO 1: ASSOCIAR-PEDIDO =====');

--- a/server.js
+++ b/server.js
@@ -19477,6 +19477,25 @@ async function ensureComprasSchema() {
       )
     `);
 
+    // Garante a categoria operacional usada no fluxo curto de compras.
+    await pool.query(`
+      INSERT INTO configuracoes.categoria_compra (
+        codigo,
+        descricao,
+        conta_despesa,
+        conta_inativa,
+        categoria_superior,
+        updated_at
+      )
+      VALUES ('2.01.93', 'Embalagem Dos Produtos', 'S', 'N', '2.01', NOW())
+      ON CONFLICT (codigo) DO UPDATE SET
+        descricao = EXCLUDED.descricao,
+        conta_despesa = EXCLUDED.conta_despesa,
+        conta_inativa = EXCLUDED.conta_inativa,
+        categoria_superior = EXCLUDED.categoria_superior,
+        updated_at = NOW()
+    `);
+
     // Insere departamentos padrão se não existirem
     await pool.query(`
       INSERT INTO configuracoes.departamento (nome) 
@@ -19502,6 +19521,7 @@ async function ensureComprasSchema() {
       INSERT INTO configuracoes.centro_custo (nome)
       VALUES
         ('Materia prima'),
+        ('Embalagem dos produtos'),
         ('Investimento na produção'),
         ('Maquinas e equipamentos'),
         ('Manutenção'),

--- a/server.js
+++ b/server.js
@@ -29928,6 +29928,13 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
     let ufNfeRegraCfop = '';
     let cfopCalculado = null;
 
+    const dHoje = (() => {
+      const d = new Date();
+      const dd = String(d.getDate()).padStart(2, '0');
+      const mm = String(d.getMonth() + 1).padStart(2, '0');
+      return `${dd}/${mm}/${d.getFullYear()}`;
+    })();
+
     if (nCodCC) {
       try {
         // Busca dados atuais do recebimento + unidades do pedido
@@ -30083,12 +30090,6 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
         }
 
         // --- infoAdicionais: dRegistro = hoje, nIdConta = nCodCC ---
-        const dHoje = (() => {
-          const d = new Date();
-          const dd = String(d.getDate()).padStart(2, '0');
-          const mm = String(d.getMonth() + 1).padStart(2, '0');
-          return `${dd}/${mm}/${d.getFullYear()}`;
-        })();
         // novaCategoriaCompra: substitui a categoria inativa se o usuário selecionou uma nova
         const categoriaParaInforAdic = novaCategoriaCompra || recebAtual?.infoAdicionais?.cCategCompra || undefined;
         infoAdicionaisParaEnviar = {
@@ -30160,6 +30161,16 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
       }
     }
 
+    if (novaCategoriaCompra && !infoAdicionaisParaEnviar) {
+      infoAdicionaisParaEnviar = {
+        cCategCompra: novaCategoriaCompra,
+        dRegistro: dHoje,
+        ...(nCodCC ? { nIdConta: nCodCC } : {})
+      };
+      cCategCompraRegraCfop = novaCategoriaCompra;
+      console.log(`[Compras/NFeAssociarPedido] infoAdicionais fallback montado para categoria=${novaCategoriaCompra}`);
+    }
+
     // ─── Passo 1: associação do pedido (PRIMEIRO, pois pode resetar dados financeiros) ───
     // Se houver troca de categoria, ela precisa ir junto com a associação.
     // A Omie pode validar a categoria antiga já no vínculo do pedido antes do Passo 2.
@@ -30204,7 +30215,51 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
           tentativasMaximas: 2
         });
         console.log('[Compras/NFeAssociarPedido] Parcelas/infoAdicionais atualizados com sucesso.');
+
+        if (novaCategoriaCompra) {
+          let categoriaConfirmada = '';
+          try {
+            const recebConf = await chamarApiRecebimentoNfeOmieComRetryRedundant('ConsultarRecebimento', {
+              nIdReceb: Number(plano.n_id_receb)
+            }, { tentativasMaximas: 2 });
+            categoriaConfirmada = String(
+              recebConf?.infoAdicionais?.cCategCompra
+              || recebConf?.cabec?.cCategCompra
+              || recebConf?.cabec?.c_categoria_compra
+              || ''
+            ).trim();
+          } catch (errConf) {
+            console.warn('[Compras/NFeAssociarPedido] Falha ao confirmar categoria após AlterarRecebimento:', errConf?.message);
+          }
+
+          if (categoriaConfirmada !== novaCategoriaCompra) {
+            console.warn(`[Compras/NFeAssociarPedido] Categoria ainda não confirmada (${categoriaConfirmada || 'vazia'}). Tentando AlterarRecebimentoConcluido.`);
+            await chamarApiRecebimentoNfeOmieComRetryRedundant('AlterarRecebimentoConcluido', {
+              ide: { nIdReceb: Number(plano.n_id_receb) },
+              infoAdicionais: infoAdicionaisParaEnviar
+            }, { tentativasMaximas: 2 });
+
+            const recebConfFinal = await chamarApiRecebimentoNfeOmieComRetryRedundant('ConsultarRecebimento', {
+              nIdReceb: Number(plano.n_id_receb)
+            }, { tentativasMaximas: 2 });
+            categoriaConfirmada = String(
+              recebConfFinal?.infoAdicionais?.cCategCompra
+              || recebConfFinal?.cabec?.cCategCompra
+              || recebConfFinal?.cabec?.c_categoria_compra
+              || ''
+            ).trim();
+          }
+
+          if (categoriaConfirmada !== novaCategoriaCompra) {
+            throw new Error(`Omie não confirmou a nova categoria antes da conclusão. Esperado=${novaCategoriaCompra}, atual=${categoriaConfirmada || 'N/A'}.`);
+          }
+
+          console.log(`[Compras/NFeAssociarPedido] Categoria confirmada na Omie: ${categoriaConfirmada}`);
+        }
       } catch (errParcelas) {
+        if (novaCategoriaCompra) {
+          throw errParcelas;
+        }
         console.warn('[Compras/NFeAssociarPedido] Falha ao atualizar parcelas/infoAdicionais:', errParcelas?.message);
       }
     }


### PR DESCRIPTION
## Objetivo
Adicionar a categoria de compra `Embalagem Dos Produtos` ao fluxo curto de compras e ao modal de associação de NF-e, usando o código Omie `2.01.93`.

## Alterações
- Inclui `Embalagem dos produtos` nas categorias operacionais de Produção.
- Mapeia a categoria operacional para `2.01.93 - Embalagem Dos Produtos` nos fluxos de compra/catálogo.
- Troca o seletor de categoria da associação de NF-e para a lista curta de compras.
- Garante a categoria `2.01.93` em `configuracoes.categoria_compra` na inicialização.

## Validação
- `node --check menu_produto.js`
- `node --check server.js`