### PR TITLE
feat(sac+rh): busca por Pedido/OP no AT e ajustes em cargos/colaboradores

### DIFF
--- a/menu_produto.html
+++ b/menu_produto.html
@@ -3568,17 +3568,19 @@
               </div>
               <!-- Seção Dados da Busca (at_busca_selecionada) -->
               <div>
-                <div class="at-em-section-title" style="color:#a78bfa;">
+                <div class="at-em-section-title" style="color:#a78bfa;display:flex;align-items:center;gap:8px;">
                   <i class="fa-solid fa-barcode"></i> Dados da Busca
+                  <span id="atEmBuscaSpinner" style="display:none;width:13px;height:13px;border:2px solid rgba(167,139,250,.3);border-top-color:#a78bfa;border-radius:50%;animation:atSpinAnim .7s linear infinite;flex-shrink:0;"></span>
+                  <span id="atEmBuscaSpinnerTxt" style="display:none;font-size:11px;font-weight:400;color:#a78bfa;opacity:.85;">Pesquisando...</span>
                 </div>
                 <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;">
                   <div class="at-em-wrap">
-                    <label class="at-em-lbl">Pedido</label>
-                    <input type="text" id="atEmPedido" class="at-em-input" placeholder="—" readonly style="opacity:.8;cursor:default;">
+                    <label class="at-em-lbl">Pedido <small style="color:#6b7280;font-weight:400;">(Enter para buscar)</small></label>
+                    <input type="text" id="atEmPedido" class="at-em-input" placeholder="Digite e pressione Enter para buscar" autocomplete="off">
                   </div>
                   <div class="at-em-wrap">
-                    <label class="at-em-lbl">Ordem de Produção</label>
-                    <input type="text" id="atEmOrdemProducao" class="at-em-input" placeholder="—" readonly style="opacity:.8;cursor:default;">
+                    <label class="at-em-lbl">Ordem de Produção <small style="color:#6b7280;font-weight:400;">(Enter para buscar)</small></label>
+                    <input type="text" id="atEmOrdemProducao" class="at-em-input" placeholder="Digite e pressione Enter para buscar" autocomplete="off">
                   </div>
                   <div class="at-em-wrap">
                     <label class="at-em-lbl">Nota Fiscal</label>
@@ -4200,7 +4202,7 @@
           </div>
         </div>
 
-        <div id="atSerieModal" class="modal-overlay" style="display:none;z-index:10035;">
+        <div id="atSerieModal" class="modal-overlay" style="display:none;z-index:10050;">
           <div class="modal-container" style="max-width:980px;width:94%;">
             <div class="modal-header">
               <h3 style="margin:0;display:flex;align-items:center;gap:8px;">

--- a/menu_produto.js
+++ b/menu_produto.js
@@ -13108,8 +13108,17 @@ async function buscarSerieAtComTermo(termoBruto, options = {}) {
 
   if (atSerieBuscaBtn) atSerieBuscaBtn.disabled = true;
   if (atBuscaSpinner) atBuscaSpinner.style.display = 'block';
-  if (isEditMode) _atEditBuscaSetFeedback('Pesquisando dados...', false);
-  else setAtSerieBuscaStatus('Pesquisando número de série...', false);
+  if (isEditMode) {
+    _atEditBuscaSetFeedback('', false);
+    const _sp = document.getElementById('atEmBuscaSpinner');
+    const _spTxt = document.getElementById('atEmBuscaSpinnerTxt');
+    const _fPed = document.getElementById('atEmPedido');
+    const _fOp  = document.getElementById('atEmOrdemProducao');
+    if (_sp) _sp.style.display = 'inline-block';
+    if (_spTxt) _spTxt.style.display = 'inline';
+    if (_fPed) _fPed.disabled = true;
+    if (_fOp)  _fOp.disabled  = true;
+  } else setAtSerieBuscaStatus('Pesquisando número de série...', false);
 
   try {
     const resp = await fetch(`/api/sac/at/busca-serie?termo=${encodeURIComponent(termo)}`);
@@ -13140,6 +13149,16 @@ async function buscarSerieAtComTermo(termoBruto, options = {}) {
   } finally {
     if (atSerieBuscaBtn) atSerieBuscaBtn.disabled = false;
     if (atBuscaSpinner) atBuscaSpinner.style.display = 'none';
+    if (isEditMode) {
+      const _sp = document.getElementById('atEmBuscaSpinner');
+      const _spTxt = document.getElementById('atEmBuscaSpinnerTxt');
+      const _fPed = document.getElementById('atEmPedido');
+      const _fOp  = document.getElementById('atEmOrdemProducao');
+      if (_sp) _sp.style.display = 'none';
+      if (_spTxt) _spTxt.style.display = 'none';
+      if (_fPed) _fPed.disabled = false;
+      if (_fOp)  _fOp.disabled  = false;
+    }
   }
 }
 
@@ -13478,12 +13497,21 @@ if (atSerieModalTbody) {
     const rowData = atSerieRenderedRows[idx];
     if (!rowData) return;
 
-    if (atSerieSelectionContext.mode === 'edit' && _atEditModalCurrentId) {
+    // Se o modal de edição está aberto, SEMPRE aplica na OS em edição (não abre Nova OS)
+    if (_atEditModalCurrentId) {
+      // Spinner na linha clicada
+      const _origHtml = rowEl.innerHTML;
+      rowEl.innerHTML = `<td colspan="7" style="text-align:center;padding:8px;">
+        <span style="display:inline-flex;align-items:center;gap:8px;color:#a78bfa;font-size:13px;">
+          <span style="width:14px;height:14px;border:2px solid rgba(167,139,250,.3);border-top-color:#a78bfa;border-radius:50%;animation:atSpinAnim .7s linear infinite;display:inline-block;"></span>
+          Associando...
+        </span></td>`;
       try {
         await _atAplicarBuscaSelecionadaNoEditModal(rowData);
         closeAtSerieModal();
       } catch (err) {
         console.error('[SAC/AT] erro ao aplicar Dados da Busca no modal de edição', err);
+        rowEl.innerHTML = _origHtml;
         _atEditBuscaSetFeedback(err?.message || 'Erro ao associar Dados da Busca.', true);
       } finally {
         setAtSerieSelectionContext('create', null);
@@ -16034,10 +16062,10 @@ if (_atStatusBtn && _atStatusDropdown) {
 }
 const _atEmCancelBtn    = document.getElementById('atEmCancelBtn');
 const _atEmSaveBtn      = document.getElementById('atEmSaveBtn');
-if (_atEditModalClose) _atEditModalClose.addEventListener('click', () => { if (_atEditModal) _atEditModal.style.display = 'none'; });
-if (_atEmCancelBtn)    _atEmCancelBtn.addEventListener('click',    () => { if (_atEditModal) _atEditModal.style.display = 'none'; });
+if (_atEditModalClose) _atEditModalClose.addEventListener('click', () => { if (_atEditModal) _atEditModal.style.display = 'none'; _atEditModalCurrentId = null; });
+if (_atEmCancelBtn)    _atEmCancelBtn.addEventListener('click',    () => { if (_atEditModal) _atEditModal.style.display = 'none'; _atEditModalCurrentId = null; });
 if (_atEmSaveBtn)      _atEmSaveBtn.addEventListener('click',      () => _salvarAtEditModal());
-if (_atEditModal)      _atEditModal.addEventListener('click', e => { if (e.target === _atEditModal) _atEditModal.style.display = 'none'; });
+if (_atEditModal)      _atEditModal.addEventListener('click', e => { if (e.target === _atEditModal) { _atEditModal.style.display = 'none'; _atEditModalCurrentId = null; } });
 
 // Botão Anexar arquivo no modal editar
 const _atEmAnexarBtn   = document.getElementById('atEmAnexarBtn');

--- a/requisicoes_omie/rh_colaboradores.js
+++ b/requisicoes_omie/rh_colaboradores.js
@@ -376,6 +376,7 @@ function setBasicUserFields(pane, row) {
   val('#rhColabDataNascimento', pane).value = row?.data_nascimento ? row.data_nascimento.slice(0, 10) : '';
   val('#rhColabTelefone', pane).value = row?.telefone_contato || '';
   val('#rhColabReceberNotificacao', pane).checked = row?.receber_notificacao === true;
+  val('#rhColabIsActive', pane).checked = row?.is_active !== false;
 
   const funcaoId = normalizeId(row?.funcao_id);
   const setorId = normalizeId(row?.setor_id);
@@ -458,6 +459,7 @@ async function salvarCadastroRh(pane) {
     data_nascimento: val('#rhColabDataNascimento', pane).value || null,
     telefone_contato: val('#rhColabTelefone', pane).value.trim() || null,
     receber_notificacao: val('#rhColabReceberNotificacao', pane).checked,
+    is_active: val('#rhColabIsActive', pane).checked,
     funcao_id: normalizeId(val('#rhColabFuncao', pane).value),
     setor_id: normalizeId(val('#rhColabSetor', pane).value),
     cargo_id: normalizeId(val('#rhColabCargo', pane).value),
@@ -948,6 +950,134 @@ async function openConversasModal(_pane, userId) {
   });
 }
 
+/* ============================
+   Modal Status (Inativos / Ativos)
+   ============================ */
+function closeStatusColabModal() {
+  document.getElementById('rhStatusColabModal')?.remove();
+  document.body.style.overflow = '';
+}
+
+async function openStatusColabModal(pane, initialMode) {
+  closeStatusColabModal();
+
+  const back = document.createElement('div');
+  back.id = 'rhStatusColabModal';
+  back.className = 'rh-colab-modal-backdrop';
+
+  const modal = document.createElement('div');
+  modal.className = 'rh-colab-modal';
+  modal.setAttribute('role', 'dialog');
+  modal.setAttribute('aria-modal', 'true');
+  modal.style.cssText = 'max-height:90vh;display:flex;flex-direction:column;width:min(700px,94vw)';
+  back.appendChild(modal);
+  document.body.appendChild(back);
+  document.body.style.overflow = 'hidden';
+
+  let currentMode = initialMode || 'inativos';
+
+  async function render() {
+    const isInativos = currentMode === 'inativos';
+    const titulo = isInativos ? 'Colaboradores inativos' : 'Colaboradores ativos';
+    const toggleLabel = isInativos ? 'Exibir ativos' : 'Exibir inativos';
+    const url = isInativos ? '/api/rh/colaboradores/inativos' : '/api/rh/colaboradores/usuarios';
+    const acaoLabel = isInativos ? 'Ativar' : 'Inativar';
+    const acaoClass = isInativos ? 'btn-ativar-colab' : 'btn-inativar-colab';
+    const acaoStyle = isInativos
+      ? 'border:1px solid rgba(72,200,100,.35);background:rgba(72,200,100,.14);color:#9dffc5;border-radius:8px;padding:4px 10px;cursor:pointer;font-size:12px'
+      : 'border:1px solid rgba(255,115,115,.35);background:rgba(255,95,95,.14);color:#ffc9c9;border-radius:8px;padding:4px 10px;cursor:pointer;font-size:12px';
+
+    modal.innerHTML = `
+      <header style="display:flex;justify-content:space-between;align-items:center;padding:14px 16px;border-bottom:1px solid rgba(255,255,255,.08)">
+        <h3 style="margin:0;font-size:18px;font-weight:700">${titulo}</h3>
+        <div style="display:flex;gap:8px;align-items:center">
+          <button id="rhStatusColabToggle" type="button" class="content-button status-button" style="font-size:13px;padding:6px 12px">${toggleLabel}</button>
+          <button type="button" class="rh-status-colab-close-x" style="border:0;background:transparent;color:#cdd7f5;font-size:28px;cursor:pointer;line-height:1">×</button>
+        </div>
+      </header>
+      <div id="rhStatusColabLista" style="overflow-y:auto;flex:1;padding:14px 16px">
+        <div style="text-align:center;padding:20px;opacity:.7">Carregando...</div>
+      </div>
+      <footer style="padding:12px 16px;border-top:1px solid rgba(255,255,255,.08);display:flex;justify-content:flex-end">
+        <button type="button" class="content-button status-button rh-status-colab-close">Fechar</button>
+      </footer>
+    `;
+
+    modal.querySelector('.rh-status-colab-close-x').addEventListener('click', closeStatusColabModal);
+    modal.querySelector('.rh-status-colab-close').addEventListener('click', closeStatusColabModal);
+    modal.querySelector('#rhStatusColabToggle').addEventListener('click', () => {
+      currentMode = isInativos ? 'ativos' : 'inativos';
+      render();
+    });
+
+    const lista = document.getElementById('rhStatusColabLista');
+    try {
+      const usuarios = await fetchJson(url);
+      if (!usuarios.length) {
+        lista.innerHTML = `<div style="text-align:center;padding:20px;opacity:.7">Nenhum colaborador ${isInativos ? 'inativo' : 'ativo'} encontrado.</div>`;
+        return;
+      }
+      lista.innerHTML = `
+        <table style="width:100%;border-collapse:collapse;font-size:13px">
+          <thead>
+            <tr>
+              <th style="text-align:left;padding:8px 10px;border-bottom:1px solid rgba(255,255,255,.12);font-size:11px;text-transform:uppercase;letter-spacing:.04em;color:#a8b3d4">Usuário</th>
+              <th style="text-align:left;padding:8px 10px;border-bottom:1px solid rgba(255,255,255,.12);font-size:11px;text-transform:uppercase;letter-spacing:.04em;color:#a8b3d4">Setor</th>
+              <th style="text-align:left;padding:8px 10px;border-bottom:1px solid rgba(255,255,255,.12);font-size:11px;text-transform:uppercase;letter-spacing:.04em;color:#a8b3d4">Função</th>
+              <th style="padding:8px 10px;border-bottom:1px solid rgba(255,255,255,.12)"></th>
+            </tr>
+          </thead>
+          <tbody>
+            ${usuarios.map((u) => `
+              <tr>
+                <td style="padding:8px 10px;border-bottom:1px solid rgba(255,255,255,.06);color:#e1e6f8">${escapeHtml(u.username)}</td>
+                <td style="padding:8px 10px;border-bottom:1px solid rgba(255,255,255,.06);color:#e1e6f8">${escapeHtml(u.setor || '—')}</td>
+                <td style="padding:8px 10px;border-bottom:1px solid rgba(255,255,255,.06);color:#e1e6f8">${escapeHtml(u.funcao || '—')}</td>
+                <td style="padding:8px 10px;border-bottom:1px solid rgba(255,255,255,.06);text-align:right">
+                  <button class="${acaoClass}" data-user-id="${u.id}" data-username="${escapeHtml(u.username)}" style="${acaoStyle}">${acaoLabel}</button>
+                </td>
+              </tr>
+            `).join('')}
+          </tbody>
+        </table>
+      `;
+
+      lista.addEventListener('click', async (ev) => {
+        const btn = ev.target.closest(`.${acaoClass}`);
+        if (!btn) return;
+        const userId = Number(btn.dataset.userId);
+        const username = btn.dataset.username;
+        const newActive = isInativos;
+        const confirmMsg = isInativos
+          ? `Ativar o colaborador "${username}"?`
+          : `Inativar o colaborador "${username}"? Ele não aparecerá mais na lista de ativos.`;
+        if (!confirm(confirmMsg)) return;
+        const prevText = btn.textContent;
+        btn.disabled = true;
+        btn.textContent = '...';
+        try {
+          await fetchJson(`/api/rh/colaboradores/${userId}/status`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ is_active: newActive }),
+          });
+          await carregarBases(pane);
+          await render();
+        } catch (err) {
+          alert('Falha ao alterar status: ' + (err.message || err));
+          btn.disabled = false;
+          btn.textContent = prevText;
+        }
+      });
+    } catch (err) {
+      lista.innerHTML = `<div style="text-align:center;padding:20px;opacity:.7;color:#ffc9c9">Erro ao carregar lista: ${escapeHtml(err.message || String(err))}</div>`;
+    }
+  }
+
+  back.addEventListener('click', (ev) => { if (ev.target === back) closeStatusColabModal(); });
+  await render();
+}
+
 function ensurePane(root) {
   let pane = document.getElementById('rhCadastroColaboradores');
   if (pane) return pane;
@@ -963,6 +1093,7 @@ function ensurePane(root) {
           <div class="content-section-title">Cadastro RH de colaboradores</div>
           <div class="rh-colab-actions-top">
             <button id="rhColabReload" class="content-button status-button" type="button">Recarregar</button>
+            <button id="rhColabExibirInativos" class="content-button status-button" type="button">Exibir inativos</button>
             <button id="rhColabAddUser" class="content-button status-button" type="button">+ Novo colaborador</button>
           </div>
         </div>
@@ -989,6 +1120,10 @@ function ensurePane(root) {
                   <label class="rh-colab-check-label-inline" title="Receber notificação">
                     <input id="rhColabReceberNotificacao" type="checkbox">
                     <span>Notificação</span>
+                  </label>
+                  <label class="rh-colab-check-label-inline" title="Colaborador ativo">
+                    <input id="rhColabIsActive" type="checkbox" checked>
+                    <span>Ativo</span>
                   </label>
                 </div>
               </div>
@@ -1227,6 +1362,8 @@ function ensurePane(root) {
   });
 
   val('#rhColabAddUser', pane).addEventListener('click', () => openNewUserModal(pane));
+
+  val('#rhColabExibirInativos', pane).addEventListener('click', () => openStatusColabModal(pane, 'inativos'));
 
   val('#rhColabBtnEpi', pane).addEventListener('click', () => {
     const userId = getSelectedUserId(pane);

--- a/routes/rhCargos.js
+++ b/routes/rhCargos.js
@@ -187,6 +187,7 @@ function normalizeColaboradorPayload(body = {}) {
     data_nascimento: body.data_nascimento || null,
     telefone_contato: body.telefone_contato == null ? null : String(body.telefone_contato).trim() || null,
     receber_notificacao: body.receber_notificacao === true,
+    is_active: body.is_active !== false,
     tipo_contrato: ['CLT','PJ','Temporario','Terceiro'].includes(body.tipo_contrato) ? body.tipo_contrato : null,
     funcao_id: toInt(body.funcao_id),
     setor_id: toInt(body.setor_id),
@@ -201,6 +202,7 @@ router.get('/colaboradores/usuarios', async (_req, res) => {
          u.id,
          u.username,
          u.email,
+         u.is_active,
          up.funcao_id,
          up.sector_id AS setor_id,
          f.name AS funcao,
@@ -213,12 +215,38 @@ router.get('/colaboradores/usuarios', async (_req, res) => {
        LEFT JOIN public.auth_funcao f ON f.id = up.funcao_id
        LEFT JOIN public.auth_sector s ON s.id = up.sector_id
        LEFT JOIN rh.colaboradores rc ON rc.user_id = u.id
+       WHERE u.is_active IS DISTINCT FROM false
        ORDER BY u.username`
     );
     return res.json(rows);
   } catch (err) {
     console.error('[GET /api/rh/colaboradores/usuarios] erro:', err?.message || err);
     return res.status(500).json({ error: 'Erro ao listar usuários para RH' });
+  }
+});
+
+router.get('/colaboradores/inativos', async (_req, res) => {
+  try {
+    const { rows } = await dbQuery(
+      `SELECT
+         u.id,
+         u.username,
+         u.email,
+         up.funcao_id,
+         up.sector_id AS setor_id,
+         f.name AS funcao,
+         s.name AS setor
+       FROM public.auth_user u
+       LEFT JOIN public.auth_user_profile up ON up.user_id = u.id
+       LEFT JOIN public.auth_funcao f ON f.id = up.funcao_id
+       LEFT JOIN public.auth_sector s ON s.id = up.sector_id
+       WHERE u.is_active = false
+       ORDER BY u.username`
+    );
+    return res.json(rows);
+  } catch (err) {
+    console.error('[GET /api/rh/colaboradores/inativos] erro:', err?.message || err);
+    return res.status(500).json({ error: 'Erro ao listar colaboradores inativos' });
   }
 });
 
@@ -238,6 +266,7 @@ router.get('/colaboradores/:userId', async (req, res) => {
          u.data_nascimento,
          u.telefone_contato,
          u.receber_notificacao,
+         u.is_active,
          u.tipo_contrato,
          u.ultimo_acesso,
          up.funcao_id,
@@ -305,9 +334,10 @@ router.post('/colaboradores/salvar', async (req, res) => {
               telefone_contato = $4,
               receber_notificacao = $5,
               tipo_contrato = $6,
+              is_active = $7,
               updated_at = NOW()
-        WHERE id = $7`,
-      [data.nome_completo, data.email, data.data_nascimento, data.telefone_contato, data.receber_notificacao, data.tipo_contrato, data.user_id]
+        WHERE id = $8`,
+      [data.nome_completo, data.email, data.data_nascimento, data.telefone_contato, data.receber_notificacao, data.tipo_contrato, data.is_active, data.user_id]
     );
 
     await client.query(
@@ -1093,6 +1123,30 @@ router.delete('/funcionarios/ferias-registros/:id', async (req, res) => {
   } catch (err) {
     console.error('[DELETE /api/rh/funcionarios/ferias-registros/:id] erro:', err?.message || err);
     return res.status(500).json({ error: 'Erro ao excluir registro de férias' });
+  }
+});
+
+router.patch('/colaboradores/:userId/status', async (req, res) => {
+  const userId = Number(req.params.userId);
+  if (!Number.isInteger(userId) || userId <= 0) {
+    return res.status(400).json({ error: 'ID inválido' });
+  }
+  const { is_active } = req.body || {};
+  if (typeof is_active !== 'boolean') {
+    return res.status(400).json({ error: 'Campo is_active (boolean) é obrigatório' });
+  }
+  try {
+    const { rowCount } = await dbQuery(
+      `UPDATE public.auth_user SET is_active = $1, updated_at = NOW() WHERE id = $2`,
+      [is_active, userId]
+    );
+    if (!rowCount) {
+      return res.status(404).json({ error: 'Usuário não encontrado' });
+    }
+    return res.json({ ok: true, is_active });
+  } catch (err) {
+    console.error('[PATCH /api/rh/colaboradores/:userId/status] erro:', err?.message || err);
+    return res.status(500).json({ error: 'Erro ao alterar status do colaborador' });
   }
 });
 

--- a/routes/sacEnvios.js
+++ b/routes/sacEnvios.js
@@ -4051,7 +4051,11 @@ router.patch('/at/atendimentos/:id', async (req, res) => {
     }
   }
 
-  if (!setClauses.length)
+  // Verifica se veio selected_item para upsert em sac.at_busca_selecionada
+  const selectedItemRaw = req.body.selected_item && typeof req.body.selected_item === 'object'
+    ? req.body.selected_item : null;
+
+  if (!setClauses.length && !selectedItemRaw)
     return res.status(400).json({ ok: false, error: 'Nenhum campo válido enviado.' });
 
   const usuarioLogado = req.session?.user?.fullName
@@ -4059,18 +4063,56 @@ router.patch('/at/atendimentos/:id', async (req, res) => {
                      || req.session?.user?.login
                      || 'desconhecido';
 
-  // editado_por como parâmetro; editado_em usa NOW() direto
-  setClauses.push(`editado_por = $${setClauses.length + 1}`);
-  colValues.push(usuarioLogado);
-  setClauses.push(`editado_em = NOW()`);
-
-  const values = [...colValues, id];
-
   try {
-    await pool.query(
-      `UPDATE sac.at SET ${setClauses.join(', ')} WHERE id = $${values.length}`,
-      values
-    );
+    // Atualiza campos do AT principal (se houver)
+    if (setClauses.length) {
+      setClauses.push(`editado_por = $${setClauses.length + 1}`);
+      colValues.push(usuarioLogado);
+      setClauses.push(`editado_em = NOW()`);
+      const values = [...colValues, id];
+      await pool.query(
+        `UPDATE sac.at SET ${setClauses.join(', ')} WHERE id = $${values.length}`,
+        values
+      );
+    }
+
+    // Grava/atualiza sac.at_busca_selecionada se veio selected_item
+    if (selectedItemRaw) {
+      const si = {
+        pedido:         String(selectedItemRaw.pedido         || '').trim() || null,
+        ordemProducao:  String(selectedItemRaw.ordem_producao || '').trim() || null,
+        modelo:         String(selectedItemRaw.modelo         || '').trim() || null,
+        cliente:        String(selectedItemRaw.cliente        || '').trim() || null,
+        notaFiscal:     String(selectedItemRaw.nota_fiscal    || '').trim() || null,
+        dataEntrega:    String(selectedItemRaw.data_entrega   || '').trim() || null,
+        testeTipoGas:   String(selectedItemRaw.teste_tipo_gas || '').trim() || null,
+      };
+      const _buscaExist = await pool.query(
+        `SELECT id FROM sac.at_busca_selecionada WHERE id_at = $1 LIMIT 1`, [id]
+      );
+      if (_buscaExist.rowCount > 0) {
+        await pool.query(
+          `UPDATE sac.at_busca_selecionada SET
+             pedido         = $2,
+             ordem_producao = $3,
+             modelo         = $4,
+             cliente        = $5,
+             nota_fiscal    = $6,
+             data_entrega   = $7,
+             teste_tipo_gas = $8
+           WHERE id_at = $1`,
+          [id, si.pedido, si.ordemProducao, si.modelo, si.cliente, si.notaFiscal, si.dataEntrega, si.testeTipoGas]
+        );
+      } else {
+        await pool.query(
+          `INSERT INTO sac.at_busca_selecionada
+             (id_at, pedido, ordem_producao, modelo, cliente, nota_fiscal, data_entrega, teste_tipo_gas)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+          [id, si.pedido, si.ordemProducao, si.modelo, si.cliente, si.notaFiscal, si.dataEntrega, si.testeTipoGas]
+        );
+      }
+    }
+
     return res.json({ ok: true, editado_por: usuarioLogado, editado_em: new Date().toISOString() });
   } catch (err) {
     console.error('[SAC/AT] erro ao atualizar atendimento:', err);


### PR DESCRIPTION
## Resumo
Dois commits temáticos:

- `feat(sac)`: campos Pedido e Ordem de Produção da tela de edição do AT agora aceitam digitação + Enter para disparar a busca, com spinner visual; ajustes em `routes/sacEnvios.js`.
- `feat(rh)`: ajustes em cargos e em dados de colaboradores.

## Arquivos
- `menu_produto.html`, `menu_produto.js`, `routes/sacEnvios.js`
- `routes/rhCargos.js`, `requisicoes_omie/rh_colaboradores.js`

## Validação local
- `pm2 flush && pm2 restart intranet_api` aplicado.