### PR TITLE
feat(compras): corrigir categoria embalagem no carrinho

### DIFF
--- a/menu_produto.html
+++ b/menu_produto.html
@@ -8473,7 +8473,7 @@
   <!-- Interceptor de sessão: precisa carregar ANTES de qualquer módulo que faça fetch -->
   <script src="/public/js/sessao_resiliente.js?v=20260422a"></script>
   <script type="module" src="login/login.js"></script>
-  <script type="module" src="menu_produto.js?v=20260505f"></script>
+  <script type="module" src="menu_produto.js?v=20260505g"></script>
   
   <script type="module" src="./requisicoes_omie/filtro_produto.js"></script>
   <script type="module" src="./requisicoes_omie/ListarProdutos.js"></script>

--- a/menu_produto.html
+++ b/menu_produto.html
@@ -8473,7 +8473,7 @@
   <!-- Interceptor de sessão: precisa carregar ANTES de qualquer módulo que faça fetch -->
   <script src="/public/js/sessao_resiliente.js?v=20260422a"></script>
   <script type="module" src="login/login.js"></script>
-  <script type="module" src="menu_produto.js?v=20260430d"></script>
+  <script type="module" src="menu_produto.js?v=20260505e"></script>
   
   <script type="module" src="./requisicoes_omie/filtro_produto.js"></script>
   <script type="module" src="./requisicoes_omie/ListarProdutos.js"></script>

--- a/menu_produto.html
+++ b/menu_produto.html
@@ -8473,7 +8473,7 @@
   <!-- Interceptor de sessão: precisa carregar ANTES de qualquer módulo que faça fetch -->
   <script src="/public/js/sessao_resiliente.js?v=20260422a"></script>
   <script type="module" src="login/login.js"></script>
-  <script type="module" src="menu_produto.js?v=20260505e"></script>
+  <script type="module" src="menu_produto.js?v=20260505f"></script>
   
   <script type="module" src="./requisicoes_omie/filtro_produto.js"></script>
   <script type="module" src="./requisicoes_omie/ListarProdutos.js"></script>

--- a/menu_produto.js
+++ b/menu_produto.js
@@ -24744,14 +24744,14 @@ async function carregarDepartamentosCarrinho() {
     if (padrao) select.value = padrao;
 
     // Atualiza categorias do carrinho ao selecionar departamento
-    select.onchange = () => {
+    select.onchange = async () => {
       atualizarCategoriasPorDepartamento(select.value, 'carrinhoCentroCustoGlobal');
-      aplicarCategoriaPadraoCarrinho();
+      await aplicarCategoriaPadraoCarrinho();
     };
 
     // Inicializa categorias com o departamento atual (se houver)
     atualizarCategoriasPorDepartamento(select.value, 'carrinhoCentroCustoGlobal');
-    aplicarCategoriaPadraoCarrinho();
+    await aplicarCategoriaPadraoCarrinho({ render: false });
   } catch (err) {
     console.error('[CARRINHO] Erro ao carregar departamentos:', err);
     select.innerHTML = '<option value="">Selecione...</option>';
@@ -24760,17 +24760,39 @@ async function carregarDepartamentosCarrinho() {
 }
 
 // Define "Materia prima" como padrão no carrinho quando disponível
-function aplicarCategoriaPadraoCarrinho() {
+async function aplicarCategoriaPadraoCarrinho(options = {}) {
+  const opts = options || {};
   const select = document.getElementById('carrinhoCentroCustoGlobal');
-  if (!select || select.value) return;
+  if (!select) return;
 
-  const option = Array.from(select.options).find(opt =>
-    (opt.value || '').toLowerCase() === 'materia prima' ||
-    (opt.textContent || '').toLowerCase() === 'materia prima'
-  );
+  if (!select.value) {
+    const option = Array.from(select.options).find(opt =>
+      (opt.value || '').toLowerCase() === 'materia prima' ||
+      (opt.textContent || '').toLowerCase() === 'materia prima'
+    );
 
-  if (option) {
-    select.value = option.value;
+    if (option) {
+      select.value = option.value;
+    }
+  }
+
+  const centroCusto = (select.value || '').trim();
+  if (!centroCusto) return;
+
+  const carrinho = window.carrinhoCompras || [];
+  let alterouAlgumItem = false;
+  await Promise.all(carrinho.map(async (item) => {
+    item.centro_custo = centroCusto || item.centro_custo || '';
+    const alterouCategoria = aplicarCategoriaCompraOmieOperacionalNoItem(item, centroCusto);
+    if (alterouCategoria) {
+      alterouAlgumItem = true;
+      await atualizarItemCarrinhoNoBanco(item);
+    }
+  }));
+
+  if (alterouAlgumItem && opts.render !== false) {
+    renderCarrinhoCompras();
+    renderModalCarrinhoCompras();
   }
 }
 

--- a/menu_produto.js
+++ b/menu_produto.js
@@ -24656,6 +24656,33 @@ function obterUsuarioLogado() {
          '';
 }
 
+function garantirCategoriasPadraoProducao(map = window.categoriasPorDepartamento) {
+  if (!map) return map;
+
+  const chaveProducao = Object.keys(map).find(key =>
+    String(key || '').normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase() === 'producao'
+  ) || 'Produção';
+
+  const categorias = Array.isArray(map[chaveProducao]) ? map[chaveProducao] : [];
+  const temEmbalagem = categorias.some(cat =>
+    String(cat || '').normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase() === 'embalagem dos produtos'
+  );
+
+  if (!temEmbalagem) {
+    const idxMateriaPrima = categorias.findIndex(cat =>
+      String(cat || '').normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase() === 'materia prima'
+    );
+    if (idxMateriaPrima >= 0) {
+      categorias.splice(idxMateriaPrima, 0, 'Embalagem dos produtos');
+    } else {
+      categorias.push('Embalagem dos produtos');
+    }
+  }
+
+  map[chaveProducao] = categorias;
+  return map;
+}
+
 // Carrega departamentos e categorias do backend
 async function carregarCategoriasPorDepartamento() {
   try {
@@ -24681,7 +24708,7 @@ async function carregarCategoriasPorDepartamento() {
       const categorias = Array.isArray(dept.categorias) ? dept.categorias : [];
       map[dept.nome] = categorias.map(cat => cat.nome);
     });
-    window.categoriasPorDepartamento = map;
+    window.categoriasPorDepartamento = garantirCategoriasPadraoProducao(map);
 
     return departamentos;
   } catch (err) {
@@ -24745,6 +24772,61 @@ function aplicarCategoriaPadraoCarrinho() {
   if (option) {
     select.value = option.value;
   }
+}
+
+function obterCategoriaCompraOmieOperacionalCarrinho(centroCusto) {
+  const categoria = String(centroCusto || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .toLowerCase();
+
+  if (categoria === 'materia prima') {
+    return {
+      codigo: '2.01.03',
+      nome: '2.01.03 - Materia Prima Nacional'
+    };
+  }
+
+  if (categoria === 'embalagem dos produtos') {
+    return {
+      codigo: '2.01.93',
+      nome: '2.01.93 - Embalagem Dos Produtos'
+    };
+  }
+
+  return null;
+}
+
+function aplicarCategoriaCompraOmieOperacionalNoItem(item, centroCusto) {
+  const categoriaOmie = obterCategoriaCompraOmieOperacionalCarrinho(centroCusto);
+  if (!item || !categoriaOmie) return false;
+
+  item.categoria_compra = categoriaOmie.codigo;
+  item.categoria_compra_codigo = categoriaOmie.codigo;
+  item.categoria_compra_nome = categoriaOmie.nome;
+  return true;
+}
+
+function configurarCategoriaGlobalCarrinho() {
+  const select = document.getElementById('carrinhoCentroCustoGlobal');
+  if (!select || select.dataset.boundCategoriaGlobal) return;
+
+  select.addEventListener('change', async () => {
+    const centroCusto = (select.value || '').trim();
+    const carrinho = window.carrinhoCompras || [];
+
+    await Promise.all(carrinho.map(async (item) => {
+      item.centro_custo = centroCusto || item.centro_custo || '';
+      aplicarCategoriaCompraOmieOperacionalNoItem(item, centroCusto);
+      await atualizarItemCarrinhoNoBanco(item);
+    }));
+
+    renderCarrinhoCompras();
+    renderModalCarrinhoCompras();
+  });
+
+  select.dataset.boundCategoriaGlobal = '1';
 }
 
 // Configura o Prazo Solicitado global do carrinho
@@ -25022,6 +25104,7 @@ window.abrirModalCarrinhoCompras = async function() {
   configurarCompraRealizadaGlobalCarrinho();
   await carregarCategoriasPorDepartamento();
   await carregarDepartamentosCarrinho();
+  configurarCategoriaGlobalCarrinho();
   await carregarCategoriaCompraDropdown();
   await carregarGruposRequisicaoDisponiveis();
   atualizarBlocoCompraOmieModal();
@@ -26043,6 +26126,7 @@ async function enviarPedidoModal() {
     }
     if (centroCustoGlobal) {
       item.centro_custo = centroCustoGlobal;
+      aplicarCategoriaCompraOmieOperacionalNoItem(item, centroCustoGlobal);
       console.log(`[Enviar Pedido] Item ${idx}: centro_custo aplicado = ${centroCustoGlobal}`);
     }
     if (prazoSolicitadoGlobal) {
@@ -26680,6 +26764,7 @@ async function carregarDepartamentosECentros() {
 function atualizarCategoriasPorDepartamento(departamento, selectId = 'modalComprasCentroCusto') {
   const selectCategorias = document.getElementById(selectId);
   if (!selectCategorias) return;
+  garantirCategoriasPadraoProducao();
   
   if (!departamento || !window.categoriasPorDepartamento[departamento]) {
     selectCategorias.innerHTML = '<option value="">Selecione departamento</option>';
@@ -27471,7 +27556,16 @@ async function adicionarItemCarrinho(ev) {
     categoriaCompra = categoriaPadraoCodigo;
   }
   // Categorias operacionais especificas devem gravar o codigo correto da Omie.
-  const categoriaOperacionalOmie = obterCategoriaCompraOmiePorCentroCusto(centroCusto);
+  const categoriaOperacionalOmie = (() => {
+    const categoria = String(centroCusto || '')
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .trim()
+      .toLowerCase();
+    if (categoria === 'materia prima') return { codigo: '2.01.03', nome: '2.01.03 - Materia Prima Nacional' };
+    if (categoria === 'embalagem dos produtos') return { codigo: '2.01.93', nome: '2.01.93 - Embalagem Dos Produtos' };
+    return null;
+  })();
   if (categoriaOperacionalOmie) {
     categoriaCompra = categoriaOperacionalOmie.codigo;
     categoriaCompraTexto = categoriaOperacionalOmie.nome;
@@ -39269,6 +39363,7 @@ async function loadModalComprasCategoriasCompra() {
 function atualizarCategoriasPorDepartamento(departamento, selectId = 'modalComprasCentroCusto') {
   const selectCategorias = document.getElementById(selectId);
   if (!selectCategorias) return;
+  garantirCategoriasPadraoProducao();
   
   if (!departamento || !window.categoriasPorDepartamento[departamento]) {
     selectCategorias.innerHTML = '<option value="">Selecione departamento</option>';
@@ -39653,7 +39748,16 @@ async function selecionarProdutoCatalogo(codigo, descricao, event = null) {
       : categoriaCompraTexto || `${categoriaPadraoCodigo} - Outros Materiais`;
   }
   // Categorias operacionais especificas devem gravar o codigo correto da Omie.
-  const categoriaOperacionalOmie = obterCategoriaCompraOmiePorCentroCusto(centroCusto);
+  const categoriaOperacionalOmie = (() => {
+    const categoria = String(centroCusto || '')
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .trim()
+      .toLowerCase();
+    if (categoria === 'materia prima') return { codigo: '2.01.03', nome: '2.01.03 - Materia Prima Nacional' };
+    if (categoria === 'embalagem dos produtos') return { codigo: '2.01.93', nome: '2.01.93 - Embalagem Dos Produtos' };
+    return null;
+  })();
   if (categoriaOperacionalOmie) {
     categoriaCompra = categoriaOperacionalOmie.codigo;
     categoriaCompraTexto = categoriaOperacionalOmie.nome;
@@ -39933,7 +40037,16 @@ async function adicionarProdutoNaoCadastradoAoCarrinho(event) {
     categoriaCompra = categoriaPadraoCodigo;
   }
   // Categorias operacionais especificas devem gravar o codigo correto da Omie.
-  const categoriaOperacionalOmie = obterCategoriaCompraOmiePorCentroCusto(centroCusto);
+  const categoriaOperacionalOmie = (() => {
+    const categoria = String(centroCusto || '')
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .trim()
+      .toLowerCase();
+    if (categoria === 'materia prima') return { codigo: '2.01.03', nome: '2.01.03 - Materia Prima Nacional' };
+    if (categoria === 'embalagem dos produtos') return { codigo: '2.01.93', nome: '2.01.93 - Embalagem Dos Produtos' };
+    return null;
+  })();
   if (categoriaOperacionalOmie) {
     categoriaCompra = categoriaOperacionalOmie.codigo;
   }

--- a/menu_produto.js
+++ b/menu_produto.js
@@ -39534,6 +39534,13 @@ async function aplicarCategoriaCompraPorProdutoCarrinho(codigoProdutoOmie, itemI
     return null;
   }
 
+  const itemAntesDaConsulta = window.carrinhoCompras[itemIdx];
+  const categoriaOperacionalAtual = obterCategoriaCompraOmieOperacionalCarrinho(itemAntesDaConsulta?.centro_custo);
+  if (categoriaOperacionalAtual) {
+    console.log('[DEBUG CATEGORIA] Mantendo categoria operacional escolhida no carrinho:', categoriaOperacionalAtual);
+    return categoriaOperacionalAtual;
+  }
+
   try {
     const url = `/api/compras/categoria-por-produto/${encodeURIComponent(codigo)}`;
     console.log('[DEBUG CATEGORIA] Fazendo fetch para:', url);
@@ -39567,17 +39574,24 @@ async function aplicarCategoriaCompraPorProdutoCarrinho(codigoProdutoOmie, itemI
       return null;
     }
 
-    // Atualiza o item do carrinho
     if (window.carrinhoCompras[itemIdx]) {
+      const itemAtual = window.carrinhoCompras[itemIdx];
+      const categoriaOperacionalDepoisDaConsulta = obterCategoriaCompraOmieOperacionalCarrinho(itemAtual?.centro_custo);
+      if (categoriaOperacionalDepoisDaConsulta) {
+        console.log('[DEBUG CATEGORIA] Consulta atrasada ignorada para preservar categoria operacional:', categoriaOperacionalDepoisDaConsulta);
+        return categoriaOperacionalDepoisDaConsulta;
+      }
+
+      // Atualiza o item do carrinho
       console.log('[DEBUG CATEGORIA] Atualizando item no índice:', itemIdx);
       
-      window.carrinhoCompras[itemIdx].categoria_compra_codigo = categoriaCodigo;
-      window.carrinhoCompras[itemIdx].categoria_compra = categoriaDescricao;
-      window.carrinhoCompras[itemIdx].categoria_compra_nome = categoriaNome;
+      itemAtual.categoria_compra_codigo = categoriaCodigo;
+      itemAtual.categoria_compra = categoriaDescricao;
+      itemAtual.categoria_compra_nome = categoriaNome;
 
       // Atualiza no banco
       console.log('[DEBUG CATEGORIA] Salvando no banco...');
-      await atualizarItemCarrinhoNoBanco(window.carrinhoCompras[itemIdx]);
+      await atualizarItemCarrinhoNoBanco(itemAtual);
       console.log('[DEBUG CATEGORIA] Salvo no banco!');
       
       // Atualiza a UI

--- a/server.js
+++ b/server.js
@@ -19532,6 +19532,54 @@ async function ensureComprasSchema() {
         ('Outros')
       ON CONFLICT (nome) DO NOTHING
     `);
+
+    // Garante a categoria operacional no vínculo configurável de Produção usado pelo carrinho.
+    await pool.query(`
+      DO $$
+      DECLARE
+        v_departamento_id INTEGER;
+        v_ordem INTEGER;
+      BEGIN
+        IF EXISTS (
+          SELECT 1
+          FROM information_schema.tables
+          WHERE table_schema = 'configuracoes'
+            AND table_name = 'categoria_departamento'
+        ) THEN
+          SELECT id
+            INTO v_departamento_id
+            FROM configuracoes.departamento
+           WHERE nome = 'Produção'
+           LIMIT 1;
+
+          IF v_departamento_id IS NOT NULL
+             AND NOT EXISTS (
+               SELECT 1
+                 FROM configuracoes.categoria_departamento
+                WHERE departamento_id = v_departamento_id
+                  AND LOWER(TRIM(nome)) = LOWER('Embalagem dos produtos')
+             ) THEN
+            SELECT COALESCE(ordem, 0)
+              INTO v_ordem
+              FROM configuracoes.categoria_departamento
+             WHERE departamento_id = v_departamento_id
+               AND LOWER(TRIM(nome)) = LOWER('Materia prima')
+             ORDER BY ordem
+             LIMIT 1;
+
+            IF v_ordem IS NULL THEN
+              SELECT COALESCE(MAX(ordem), 0) + 1
+                INTO v_ordem
+                FROM configuracoes.categoria_departamento
+               WHERE departamento_id = v_departamento_id;
+            END IF;
+
+            INSERT INTO configuracoes.categoria_departamento (departamento_id, nome, ordem, ativo)
+            VALUES (v_departamento_id, 'Embalagem dos produtos', v_ordem, true);
+          END IF;
+        END IF;
+      END $$;
+    `);
     
     // Cria tabela de status de compras
     await pool.query(`


### PR DESCRIPTION
﻿## Objetivo
Corrigir o fluxo do carrinho de compras para que a categoria operacional "Embalagem dos produtos" também atualize a categoria Omie usada no envio.

## Alterações
- Garante "Embalagem dos produtos" nas categorias de Produção exibidas no carrinho.
- Ao selecionar "Embalagem dos produtos", atualiza o item para categoria Omie 2.01.93.
- Ao enviar o carrinho, recalcula a categoria Omie antes de montar o payload.
- Garante no backend a categoria de Produção para evitar que a configuração venha incompleta.

## Testes
- node --check menu_produto.js
- node --check server.js
- Teste local no localhost com item 11127: categoria global alterada para Embalagem dos produtos, item salvo com categoria_compra_codigo 2.01.93 e categoria_compra_nome 2.01.93 - Embalagem Dos Produtos.
