### PR TITLE
fix: sanitize Site_AT env example

### DIFF
--- a/Site_AT/.env.example
+++ b/Site_AT/.env.example
@@ -1,6 +1,6 @@
-PGHOST=dpg-d2d4b0a4d50c7385vm50-a.oregon-postgres.render.com
-PGPORT=5432
-PGDATABASE=intranet_db_yd0w
-PGUSER=intranet_db_yd0w_user
-PGPASSWORD=amLpOKjWzzDRhwcR1NF0eolJzzfCY0ho
-PORT=3000
+PGHOST=
+PGPORT=
+PGDATABASE=
+PGUSER=
+PGPASSWORD=
+PORT=


### PR DESCRIPTION
Remove valores reais do arquivo Site_AT/.env.example e mantém apenas nomes de variáveis. Recomenda-se rotacionar as credenciais que já estiveram no histórico do repositório.