### PR TITLE
feat(producao): novo modulo de producao + estoque por data + fix login standalone

### DIFF
--- a/login/login.js
+++ b/login/login.js
@@ -92,6 +92,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // 1) Pega o container onde injetaremos o HTML do login
   const overlay = document.getElementById('authOverlay');
+  if (!overlay) return; // página sem #authOverlay (ex: login.html standalone)
   
   // ⚡ OTIMIZAÇÃO: Habilita o botão profile-icon IMEDIATAMENTE
   const profileArea = document.getElementById('profile-icon');

--- a/menu_produto.html
+++ b/menu_produto.html
@@ -197,6 +197,39 @@
   </div>
 </div>
 
+<!-- Nova categoria: Produção -->
+<div class="side-wrapper">
+  <div class="side-title"
+       data-nav-key="side:producao"
+       data-nav-pos="side"
+       data-nav-label="Produção">Produção</div>
+
+  <div class="side-menu">
+    <a href="#"
+       id="menu-producao-primeira-peca-ok"
+       class="menu-link"
+       data-nav-key="side:producao:primeira-peca-ok"
+       data-nav-parent="side:producao"
+       data-nav-pos="side"
+       data-nav-label="1° pç ok"
+       data-nav-selector="#menu-producao-primeira-peca-ok">
+      <i class="fa-solid fa-circle-check" style="margin-right:8px;"></i>
+      1° pç ok
+    </a>
+    <a href="#"
+       id="menu-registrar-producao"
+       class="menu-link"
+       data-nav-key="side:producao:registrar"
+       data-nav-parent="side:producao"
+       data-nav-pos="side"
+       data-nav-label="Registrar produção"
+       data-nav-selector="#menu-registrar-producao">
+      <i class="fa-solid fa-industry" style="margin-right:8px;"></i>
+      Registrar produção
+    </a>
+  </div>
+</div>
+
 <div class="side-wrapper">
   <div class="side-title"
        data-nav-key="side:rh"
@@ -7788,6 +7821,9 @@
     <a href="#" data-arm-tab="armazem3d" class="main-header-link">
       <i class="fa-solid fa-warehouse" style="margin-right:5px;"></i>Armazém 3D
     </a>
+    <a href="#" data-arm-tab="posicao-estoque" class="main-header-link">
+      <i class="fa-solid fa-calendar-days" style="margin-right:5px;"></i>Posição de Estoque
+    </a>
   </div>
 </div>
 
@@ -7987,6 +8023,49 @@
 
   </div><!-- /arm3d-outer -->
 </div><!-- /conteudo-armazem3d -->
+
+<!-- ===================== PAINEL POSIÇÃO DE ESTOQUE ===================== -->
+<div id="conteudo-posicao-estoque" class="armazem-page" style="display:none;">
+  <div class="content-wrapper">
+    <div class="content-section">
+      <div class="title-wrapper" style="display:flex; flex-direction:column; gap:12px;">
+        <div class="content-section-title" style="margin:0;">Posição de Estoque por Data</div>
+        <div style="display:flex; align-items:center; gap:12px; flex-wrap:wrap;">
+          <label for="posicaoEstoqueDataInput" style="font-weight:600;">Data:</label>
+          <input type="date" id="posicaoEstoqueDataInput" class="transfer-select" style="min-width:180px;" />
+          <button id="posicaoEstoqueBuscarBtn" class="btn primary" style="padding:6px 18px;">
+            <i class="fa-solid fa-magnifying-glass"></i> Buscar
+          </button>
+          <input type="text" id="posicaoEstoqueSearch" placeholder="Pesquisar por código ou descrição…" class="search-box" style="max-width:280px;" />
+          <span id="posicaoEstoqueInfo" style="color:#aaa; font-size:13px;"></span>
+        </div>
+      </div>
+      <div class="almox-wrapper" style="margin-top:12px;">
+        <table id="tbl-posicao-estoque" class="tabela padrao">
+          <thead>
+            <tr>
+              <th>Código</th>
+              <th class="desc-col">Descrição</th>
+              <th>Local</th>
+              <th>Físico</th>
+              <th>Saldo</th>
+              <th>CMC</th>
+              <th>Mín</th>
+            </tr>
+          </thead>
+          <tbody id="posicaoEstoqueTbody">
+            <tr><td colspan="7" style="text-align:center; color:#aaa;">Selecione uma data e clique em Buscar.</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="almox-pager" style="margin-top:8px;">
+        <button id="posicaoEstoquePrev" class="btn tiny">◀</button>
+        <span id="posicaoEstoquePageInfo">1 / 1</span>
+        <button id="posicaoEstoqueNext" class="btn tiny">▶</button>
+      </div>
+    </div>
+  </div>
+</div><!-- /conteudo-posicao-estoque -->
 
 <style>
 /* ======================================================
@@ -8434,16 +8513,92 @@
 
 
 
+        <!-- Painel Produção: Registrar produção (Ordens de Produção IAPP) -->
+        <div id="registrarProducaoPane" class="tab-pane" style="display:none;">
+          <div class="content-wrapper">
+            <div class="content-wrapper-header">
+              <div class="content-wrapper-context">
+                <h3 class="img-content" style="display:flex;align-items:center;gap:8px;">
+                  <i class="fa-solid fa-industry" style="color:#6366f1;"></i>
+                  <span>Ordens de Produção</span>
+                </h3>
+                <div class="content-text">Dados em tempo real do IAPP — status A Produzir.</div>
+              </div>
+              <div style="display:flex;gap:8px;align-items:center;">
+                <button id="producaoRecarregarBtn" type="button"
+                  style="display:inline-flex;align-items:center;gap:8px;padding:7px 16px;background:linear-gradient(135deg,#6366f1 0%,#4f46e5 100%);color:#fff;border:none;border-radius:8px;font-size:13px;font-weight:600;cursor:pointer;">
+                  <i class="fa-solid fa-rotate-right"></i> Atualizar
+                </button>
+              </div>
+            </div>
+
+            <!-- Spinner de carregamento -->
+            <div id="producaoSpinner" style="display:none;text-align:center;padding:32px 0;color:#6366f1;">
+              <i class="fa-solid fa-spinner fa-spin" style="font-size:28px;"></i>
+              <div style="margin-top:10px;font-size:13px;color:var(--inactive-color);" id="producaoSpinnerMsg">Carregando...</div>
+            </div>
+
+            <!-- Mensagem de erro -->
+            <div id="producaoErro" style="display:none;padding:16px;background:#450a0a;border:1px solid #dc2626;border-radius:10px;color:#fca5a5;font-size:13px;margin-bottom:12px;"></div>
+
+            <!-- Filtro por operação de serviço -->
+            <div id="producaoFiltroBar" style="display:none;margin-bottom:12px;">
+              <select id="producaoFiltroOperacao"
+                style="width:100%;max-width:420px;padding:7px 12px;background:#1e2233;color:#e2e8f0;border:1px solid rgba(99,102,241,.4);border-radius:8px;font-size:13px;cursor:pointer;">
+                <option value="">Todas as operações de serviço</option>
+              </select>
+            </div>
+
+            <!-- Kanban de OPs -->
+            <div id="producaoKanban" style="display:flex;gap:16px;align-items:flex-start;overflow-x:auto;padding:4px 0 16px 0;">
+
+              <!-- Coluna: Programado -->
+              <div style="flex:0 0 340px;min-width:300px;">
+                <div style="display:flex;align-items:center;gap:8px;padding:10px 14px;background:#1e1b4b;border-radius:10px 10px 0 0;border:1px solid #3730a3;border-bottom:none;">
+                  <span style="width:10px;height:10px;border-radius:50%;background:#6366f1;display:inline-block;flex-shrink:0;"></span>
+                  <span style="font-size:12px;font-weight:700;color:#a5b4fc;text-transform:uppercase;letter-spacing:.5px;">Programado</span>
+                  <span id="kanbanProgramadoCount" style="margin-left:auto;font-size:11px;background:#312e81;color:#c7d2fe;padding:2px 9px;border-radius:10px;font-weight:600;">0</span>
+                </div>
+                <div id="kanbanProgramado" style="min-height:220px;background:rgba(99,102,241,.04);border:1px solid #3730a3;border-top:none;border-radius:0 0 10px 10px;padding:10px;display:flex;flex-direction:column;gap:10px;">
+                  <div style="text-align:center;padding:24px 0;color:var(--inactive-color);font-size:12px;">Clique em "Recarregar" para carregar.</div>
+                </div>
+              </div>
+
+              <!-- Coluna: Produzindo -->
+              <div style="flex:0 0 340px;min-width:300px;">
+                <div style="display:flex;align-items:center;gap:8px;padding:10px 14px;background:#052e16;border-radius:10px 10px 0 0;border:1px solid #166534;border-bottom:none;">
+                  <span style="width:10px;height:10px;border-radius:50%;background:#22c55e;display:inline-block;flex-shrink:0;"></span>
+                  <span style="font-size:12px;font-weight:700;color:#86efac;text-transform:uppercase;letter-spacing:.5px;">Produzindo</span>
+                  <span id="kanbanProduzindoCount" style="margin-left:auto;font-size:11px;background:#14532d;color:#bbf7d0;padding:2px 9px;border-radius:10px;font-weight:600;">0</span>
+                </div>
+                <div id="kanbanProduzindo" style="min-height:220px;background:rgba(34,197,94,.04);border:1px solid #166534;border-top:none;border-radius:0 0 10px 10px;padding:10px;display:flex;flex-direction:column;gap:10px;">
+                  <div style="text-align:center;padding:24px 0;color:var(--inactive-color);font-size:12px;">Nenhuma OP em produção.</div>
+                </div>
+              </div>
+
+              <!-- Coluna: Aguardando Retirada -->
+              <div style="flex:0 0 340px;min-width:300px;">
+                <div style="display:flex;align-items:center;gap:8px;padding:10px 14px;background:#431407;border-radius:10px 10px 0 0;border:1px solid #9a3412;border-bottom:none;">
+                  <span style="width:10px;height:10px;border-radius:50%;background:#f97316;display:inline-block;flex-shrink:0;"></span>
+                  <span style="font-size:12px;font-weight:700;color:#fdba74;text-transform:uppercase;letter-spacing:.5px;">Aguardando Retirada</span>
+                  <span id="kanbanAguardandoCount" style="margin-left:auto;font-size:11px;background:#7c2d12;color:#fed7aa;padding:2px 9px;border-radius:10px;font-weight:600;">0</span>
+                </div>
+                <div id="kanbanAguardando" style="min-height:220px;background:rgba(249,115,22,.04);border:1px solid #9a3412;border-top:none;border-radius:0 0 10px 10px;padding:10px;display:flex;flex-direction:column;gap:10px;">
+                  <div style="text-align:center;padding:24px 0;color:var(--inactive-color);font-size:12px;">Nenhuma OP aguardando retirada.</div>
+                </div>
+              </div>
+
+            </div>
+
+            <!-- Rodapé de contagem -->
+            <div id="producaoRodape" style="display:none;margin-top:4px;font-size:12px;color:var(--inactive-color);text-align:right;padding:0 4px;"></div>
+          </div>
+        </div>
+
       </div> <!-- /.main-container -->
 
 
-
-
-
     </div> <!-- /.wrapper -->
-
-    <div class="overlay-app" id="authOverlay"></div>
-  </div> <!-- /.app -->
 
 
 

--- a/menu_produto.js
+++ b/menu_produto.js
@@ -5871,6 +5871,9 @@ else if (nome === 'transferencia') {
 else if (nome === 'armazem3d') {
   initArmazem3D();
 }
+else if (nome === 'posicao-estoque') {
+  initPosicaoEstoque();
+}
 
 }
 
@@ -52183,8 +52186,21 @@ async function applyCurrentUserPermissionsToUI(){
     if (raw) {
       const cached = JSON.parse(raw);
       if (cached && Array.isArray(cached.nodes)) {
-        _applyPermissionTreeToUI(cached);
-        appliedFromCache = true;
+        // Valida cache: verifica se todos os nós do DOM com selector estão presentes.
+        // Se faltar algum, a cache está desatualizada — descarta e busca fresh.
+        const cachedSelectors = new Set(cached.nodes.map(n => n.selector).filter(Boolean));
+        const domNodes = document.querySelectorAll('[data-nav-selector]');
+        const allPresent = Array.from(domNodes).every(el => {
+          const sel = el.dataset.navSelector;
+          return !sel || cachedSelectors.has(sel);
+        });
+        if (allPresent) {
+          _applyPermissionTreeToUI(cached);
+          appliedFromCache = true;
+        } else {
+          // Cache desatualizada (novos menus foram adicionados) — limpa e busca fresh
+          try { localStorage.removeItem(cacheKey); } catch {}
+        }
       }
     }
   } catch {}
@@ -52204,7 +52220,7 @@ async function applyCurrentUserPermissionsToUI(){
     // Não bloqueia o boot: revalida em segundo plano
     refresh();
   } else {
-    // Sem cache: precisamos esperar para não revelar UI vazia
+    // Sem cache ou cache desatualizada: aguarda para não revelar UI vazia
     await refresh();
   }
 }
@@ -52342,6 +52358,11 @@ window.syncNavNodes = async function(force = false) {
       console.warn('[nav-sync]', r.status, e);
     } else {
       window.__navSync.last = Date.now();
+      // Invalida cache de permissões e reaplica, pois podem ter sido adicionados novos nós
+      if (window.__sessionUser) {
+        try { localStorage.removeItem(`perm-tree:${window.__sessionUser.id}`); } catch {}
+        try { await window.applyCurrentUserPermissionsToUI?.(); } catch {}
+      }
     }
   } catch (e) {
     console.warn('[nav-sync] falhou', e);
@@ -61400,4 +61421,359 @@ document.addEventListener('DOMContentLoaded', () => {
 
     carregarMapa();
   };
+})();
+
+/* ============================================================
+ * PRODUÇÃO — Ordens de Produção IAPP (Kanban)
+ * ============================================================ */
+(function () {
+  const menuBtn = document.getElementById('menu-registrar-producao');
+  if (!menuBtn) return;
+
+  const spinner       = document.getElementById('producaoSpinner');
+  const spinnerMsg    = document.getElementById('producaoSpinnerMsg');
+  const erroDiv       = document.getElementById('producaoErro');
+  const rodape        = document.getElementById('producaoRodape');
+  const recarrBtn     = document.getElementById('producaoRecarregarBtn');
+  const filtroBar     = document.getElementById('producaoFiltroBar');
+  const filtroSelect  = document.getElementById('producaoFiltroOperacao');
+
+  const colProgramado = document.getElementById('kanbanProgramado');
+  const cntProgramado = document.getElementById('kanbanProgramadoCount');
+
+  // Cache das ordens carregadas para re-renderizar sem nova requisição
+  let ordensCarregadas = [];
+
+  function fmtData(str) {
+    if (!str) return '—';
+    const m = str.match(/^(\d{4})-(\d{2})-(\d{2})/);
+    if (m) return `${m[3]}/${m[2]}/${m[1]}`;
+    return str;
+  }
+
+  function fmtMoeda(v) {
+    if (v == null || v === '') return '—';
+    return 'R$ ' + Number(v).toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  }
+
+  function fmtQtde(v) {
+    if (v == null || v === '') return '—';
+    const n = parseFloat(v);
+    return isNaN(n) ? String(v) : n.toLocaleString('pt-BR', { maximumFractionDigits: 4 }).replace(/,?0+$/, '').replace(/,$/, '') || String(n);
+  }
+
+  function badgeOS(status) {
+    const cores = {
+      'ENCERRADA':    { bg: '#1e293b', txt: '#94a3b8' },
+      'ABERTA':       { bg: '#1d4ed8', txt: '#bfdbfe' },
+      'EM ANDAMENTO': { bg: '#065f46', txt: '#6ee7b7' },
+      'PAUSADA':      { bg: '#92400e', txt: '#fcd34d' },
+    };
+    const s = (status || '').toUpperCase();
+    const c = cores[s] || { bg: '#374151', txt: '#d1d5db' };
+    return `<span style="flex-shrink:0;display:inline-block;padding:1px 6px;border-radius:4px;font-size:10px;font-weight:700;background:${c.bg};color:${c.txt};">${status || '—'}</span>`;
+  }
+
+  function renderGrupo(prodId, ops) {
+    const prod = ops[0].produto || {};
+    const qtdeTotal = ops.reduce((s, op) => s + (Number(op.qtde) || 0), 0);
+
+    const opsHtml = ops.map(op => {
+      const osHtml = (op.ordens_servico || []).map(os =>
+        `<div style="background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.06);border-radius:5px;padding:5px 8px;display:flex;flex-direction:column;gap:3px;">
+          <div style="display:flex;align-items:center;gap:6px;">
+            <span style="font-size:10px;color:#94a3b8;min-width:70px;font-weight:600;flex-shrink:0;">${os.identificacao || ('#' + os.id)}</span>
+            <span style="font-size:10px;color:#cbd5e1;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="${(os.operacao || '').replace(/"/g,'&quot;')}">${os.operacao || '—'}</span>
+            ${badgeOS(os.status)}
+          </div>
+          <div style="display:flex;flex-wrap:wrap;gap:10px;padding-left:2px;">
+            ${os.data_abertura     ? `<span style="font-size:10px;color:#64748b;">Abertura: <b style="color:#94a3b8;">${fmtData(os.data_abertura)}</b></span>` : ''}
+            ${os.data_inicio       ? `<span style="font-size:10px;color:#64748b;">Início: <b style="color:#94a3b8;">${fmtData(os.data_inicio)}</b></span>` : ''}
+            ${os.data_final        ? `<span style="font-size:10px;color:#64748b;">Final: <b style="color:#94a3b8;">${fmtData(os.data_final)}</b></span>` : ''}
+            ${os.data_encerramento ? `<span style="font-size:10px;color:#64748b;">Encerramento: <b style="color:#94a3b8;">${fmtData(os.data_encerramento)}</b></span>` : ''}
+          </div>
+        </div>`
+      ).join('');
+
+      const detalhesId = `op-det-${op.id}`;
+
+      return `<div data-op-id="${op.id}" style="background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08);border-radius:8px;padding:10px 12px;margin-top:8px;">
+        <!-- Cabeçalho sempre visível -->
+        <div style="display:flex;align-items:flex-start;gap:8px;">
+          <div style="flex:1;min-width:0;">
+            <div style="display:flex;align-items:center;gap:6px;margin-bottom:4px;">
+              <span style="font-size:10px;color:#475569;font-weight:600;">#${op.id}</span>
+              <span style="font-size:13px;font-weight:700;color:#e2e8f0;">OP ${op.identificacao || '—'}</span>
+              <span style="font-size:11px;color:#94a3b8;margin-left:auto;">Qtde: <b style="color:#f1f5f9;">${fmtQtde(op.qtde)}</b></span>
+            </div>
+            <div style="display:flex;flex-wrap:wrap;gap:8px;">
+              ${op.data_abertura             ? `<span style="font-size:10px;color:#64748b;">Abertura: <b style="color:#94a3b8;">${fmtData(op.data_abertura)}</b></span>` : ''}
+              ${op.data_inicio               ? `<span style="font-size:10px;color:#64748b;">Início: <b style="color:#94a3b8;">${fmtData(op.data_inicio)}</b></span>` : ''}
+              ${op.data_final                ? `<span style="font-size:10px;color:#64748b;">Final: <b style="color:#94a3b8;">${fmtData(op.data_final)}</b></span>` : ''}
+              ${op.data_previsao_faturamento  ? `<span style="font-size:10px;color:#64748b;">Prev. fat.: <b style="color:#a5f3fc;">${fmtData(op.data_previsao_faturamento)}</b></span>` : ''}
+              ${op.data_previsao_entrega     ? `<span style="font-size:10px;color:#64748b;">Prev. entrega: <b style="color:#a5f3fc;">${fmtData(op.data_previsao_entrega)}</b></span>` : ''}
+            </div>
+          </div>
+          <button onclick="(function(btn){var d=document.getElementById('${detalhesId}');var aberto=d.style.display!=='none';d.style.display=aberto?'none':'flex';btn.innerHTML=aberto?'<i class=\\'fa-solid fa-chevron-down\\'></i>':'<i class=\\'fa-solid fa-chevron-up\\'></i>';})(this)"
+            style="flex-shrink:0;background:rgba(255,255,255,.07);border:1px solid rgba(255,255,255,.12);border-radius:6px;color:#94a3b8;width:26px;height:26px;display:flex;align-items:center;justify-content:center;cursor:pointer;font-size:11px;margin-top:2px;">
+            <i class="fa-solid fa-chevron-down"></i>
+          </button>
+        </div>
+        <!-- Detalhes recolhidos por padrão -->
+        <div id="${detalhesId}" style="display:none;flex-direction:column;gap:4px;margin-top:10px;padding-top:10px;border-top:1px solid rgba(255,255,255,.06);">
+          ${op.data_encerramento ? `<div style="font-size:10px;color:#64748b;">Encerramento: <b style="color:#94a3b8;">${fmtData(op.data_encerramento)}</b></div>` : ''}
+          ${op.ficha_tecnica     ? `<div style="font-size:11px;color:#94a3b8;">Ficha técnica: <span style="color:#c7d2fe;">${op.ficha_tecnica}</span></div>` : ''}
+          ${op.obs               ? `<div style="font-size:11px;color:#94a3b8;">Obs: <span style="color:#fef3c7;">${op.obs}</span></div>` : ''}
+          ${osHtml ? `<div style="display:flex;flex-direction:column;gap:4px;margin-top:4px;">${osHtml}</div>` : '<div style="font-size:11px;color:#475569;">Sem ordens de serviço.</div>'}
+        </div>
+      </div>`;
+    }).join('');
+
+    const descEscapada = (prod.descricao || '').replace(/"/g, '&quot;');
+
+    return `<div style="background:var(--content-bg,#1e2233);border:1px solid rgba(255,255,255,.1);border-radius:10px;padding:12px;">
+      <div style="display:flex;align-items:flex-start;gap:8px;margin-bottom:6px;">
+        <div style="flex:1;min-width:0;">
+          <div style="font-size:13px;font-weight:700;color:#f59e0b;letter-spacing:.3px;">${prod.identificacao || prodId}</div>
+          <div style="font-size:12px;color:#e2e8f0;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;margin-top:2px;line-height:1.4;" title="${descEscapada}">${prod.descricao || '—'}</div>
+          <div style="display:flex;flex-wrap:wrap;gap:8px;margin-top:4px;">
+            ${prod.tipo ? `<span style="font-size:10px;color:#94a3b8;">${prod.tipo}</span>` : ''}
+            ${prod.valor_custo != null ? `<span style="font-size:10px;color:#6ee7b7;font-weight:600;">${fmtMoeda(prod.valor_custo)}</span>` : ''}
+          </div>
+        </div>
+        <span style="flex-shrink:0;font-size:12px;font-weight:700;background:#312e81;color:#c7d2fe;padding:3px 10px;border-radius:12px;">QTD ${fmtQtde(qtdeTotal)}</span>
+      </div>
+      ${opsHtml}
+    </div>`;
+  }
+
+  // Renderiza o kanban com o subconjunto de ordens fornecido
+  function renderKanban(ordens) {
+    const operacaoFiltro = filtroSelect ? filtroSelect.value : '';
+
+    // Aplica filtro por operação se selecionado
+    const filtradas = operacaoFiltro
+      ? ordens.filter(op =>
+          (op.ordens_servico || []).some(os => os.operacao === operacaoFiltro)
+        )
+      : ordens;
+
+    const aProduzir = filtradas.filter(op => op.status === 'A PRODUZIR');
+
+    // Agrupa por produto.identificacao
+    const grupos = {};
+    for (const op of aProduzir) {
+      const key = op.produto?.identificacao || String(op.id);
+      if (!grupos[key]) grupos[key] = [];
+      grupos[key].push(op);
+    }
+
+    if (Object.keys(grupos).length === 0) {
+      colProgramado.innerHTML = '<div style="text-align:center;padding:24px 0;color:var(--inactive-color);font-size:12px;">'
+        + (operacaoFiltro ? `Nenhuma OP com a operação "${operacaoFiltro}".` : 'Nenhuma OP programada.')
+        + '</div>';
+    } else {
+      colProgramado.innerHTML = Object.entries(grupos)
+        .map(([key, ops]) => renderGrupo(key, ops))
+        .join('');
+    }
+
+    if (cntProgramado) cntProgramado.textContent = aProduzir.length;
+  }
+
+  async function carregarOrdens() {
+    if (!spinner || !colProgramado) return;
+    spinner.style.display = 'block';
+    if (spinnerMsg) spinnerMsg.textContent = 'Consultando IAPP...';
+    erroDiv.style.display = 'none';
+    if (rodape) rodape.style.display = 'none';
+    if (filtroBar) filtroBar.style.display = 'none';
+    colProgramado.innerHTML = '<div style="text-align:center;padding:24px 0;color:var(--inactive-color);font-size:12px;">Carregando...</div>';
+
+    try {
+      const resp = await fetch('/api/producao/ordens');
+      const data = await resp.json();
+
+      if (!resp.ok || !data.success) throw new Error(data.error || 'Erro ao consultar ordens de produção');
+
+      ordensCarregadas = data.ordens || [];
+
+      // Coleta operações únicas de todos as OSs
+      const operacoesSet = new Set();
+      for (const op of ordensCarregadas) {
+        for (const os of (op.ordens_servico || [])) {
+          if (os.operacao) operacoesSet.add(os.operacao);
+        }
+      }
+      const operacoes = [...operacoesSet].sort();
+
+      // Popula o select de filtro
+      if (filtroSelect) {
+        const valorAtual = filtroSelect.value;
+        filtroSelect.innerHTML = '<option value="">Todas as operações de serviço</option>'
+          + operacoes.map(op => `<option value="${op.replace(/"/g,'&quot;')}"${op === valorAtual ? ' selected' : ''}>${op}</option>`).join('');
+        if (filtroBar) filtroBar.style.display = operacoes.length > 0 ? 'block' : 'none';
+      }
+
+      renderKanban(ordensCarregadas);
+
+      if (rodape) {
+        rodape.style.display = 'block';
+        const sincTs = data.sincronizado_em ? ` · Consultado em: ${fmtData(String(data.sincronizado_em))}` : '';
+        rodape.textContent = `${data.total_ativas} ordem(ns) ativa(s).${sincTs}`;
+      }
+    } catch (err) {
+      erroDiv.style.display = 'block';
+      erroDiv.textContent = 'Erro: ' + (err.message || 'Falha ao carregar ordens de produção.');
+      colProgramado.innerHTML = '';
+    } finally {
+      spinner.style.display = 'none';
+    }
+  }
+
+  // Filtro: re-renderiza sem nova requisição ao mudar operação
+  if (filtroSelect) {
+    filtroSelect.addEventListener('change', () => renderKanban(ordensCarregadas));
+  }
+
+  menuBtn.addEventListener('click', (e) => {
+    e.preventDefault();
+    document.querySelectorAll('.left-side .side-menu a').forEach(a => a.classList.remove('is-active'));
+    menuBtn.classList.add('is-active');
+    showMainTab('registrarProducaoPane');
+    carregarOrdens();
+  });
+
+  if (recarrBtn) {
+    recarrBtn.addEventListener('click', () => carregarOrdens());
+  }
+})();
+
+/* =====================================================================
+   POSIÇÃO DE ESTOQUE POR DATA
+   ===================================================================== */
+(function () {
+  let posicaoAllDados = [];
+  let posicaoPagAtual = 1;
+  let posicaoTotalPag = 1;
+  let posicaoDatasDisponiveis = new Set();
+  let posicaoIniciado = false;
+
+  async function initPosicaoEstoque() {
+    if (!posicaoIniciado) {
+      posicaoIniciado = true;
+      await carregarDatasDisponiveis();
+      configurarCalendario();
+      configurarEventos();
+    }
+  }
+  window.initPosicaoEstoque = initPosicaoEstoque;
+
+  async function carregarDatasDisponiveis() {
+    try {
+      const resp = await fetch('/api/estoque/datas-disponiveis');
+      const json = await resp.json();
+      if (json.ok) {
+        posicaoDatasDisponiveis = new Set(json.datas);
+        const inp = document.getElementById('posicaoEstoqueDataInput');
+        if (inp && json.datas.length > 0) {
+          inp.value = json.datas[0]; // data mais recente como padrão
+        }
+      }
+    } catch (e) {
+      console.warn('[posicao-estoque] erro ao carregar datas:', e);
+    }
+  }
+
+  function configurarCalendario() {
+    const inp = document.getElementById('posicaoEstoqueDataInput');
+    if (!inp) return;
+    // Destacar datas disponíveis via change listener já é suficiente
+    // para input[type=date nativo]. Apenas informamos o usuário.
+    const info = document.getElementById('posicaoEstoqueInfo');
+    if (info && posicaoDatasDisponiveis.size > 0) {
+      const datas = [...posicaoDatasDisponiveis].sort();
+      info.textContent = `Datas disponíveis: ${datas[0]} até ${datas[datas.length - 1]}`;
+    }
+  }
+
+  function configurarEventos() {
+    const btnBuscar = document.getElementById('posicaoEstoqueBuscarBtn');
+    if (btnBuscar) {
+      btnBuscar.addEventListener('click', () => buscarPosicao(1));
+    }
+    const inp = document.getElementById('posicaoEstoqueDataInput');
+    if (inp) {
+      inp.addEventListener('keydown', e => { if (e.key === 'Enter') buscarPosicao(1); });
+    }
+    const inpSearch = document.getElementById('posicaoEstoqueSearch');
+    if (inpSearch) {
+      inpSearch.addEventListener('input', () => filtrarPosicaoLocal());
+    }
+    const btnPrev = document.getElementById('posicaoEstoquePrev');
+    const btnNext = document.getElementById('posicaoEstoqueNext');
+    if (btnPrev) btnPrev.addEventListener('click', () => { if (posicaoPagAtual > 1) buscarPosicao(posicaoPagAtual - 1); });
+    if (btnNext) btnNext.addEventListener('click', () => { if (posicaoPagAtual < posicaoTotalPag) buscarPosicao(posicaoPagAtual + 1); });
+  }
+
+  async function buscarPosicao(pagina) {
+    const inp = document.getElementById('posicaoEstoqueDataInput');
+    const tbody = document.getElementById('posicaoEstoqueTbody');
+    const info = document.getElementById('posicaoEstoqueInfo');
+    const pageInfo = document.getElementById('posicaoEstoquePageInfo');
+    if (!inp || !inp.value) {
+      if (info) info.textContent = 'Selecione uma data.';
+      return;
+    }
+    if (tbody) tbody.innerHTML = '<tr><td colspan="7" style="text-align:center;">⏳ Carregando...</td></tr>';
+    try {
+      const resp = await fetch(`/api/estoque/posicao-por-data?data=${inp.value}&pagina=${pagina}&limite=200`);
+      const json = await resp.json();
+      if (!json.ok) throw new Error(json.error || 'Erro desconhecido');
+      posicaoAllDados = json.dados;
+      posicaoPagAtual = json.pagina;
+      posicaoTotalPag = json.totalPaginas;
+      if (info) info.textContent = `${json.totalRegistros} registros para ${inp.value}`;
+      if (pageInfo) pageInfo.textContent = `${posicaoPagAtual} / ${posicaoTotalPag}`;
+      renderPosicaoTabela(posicaoAllDados);
+    } catch (err) {
+      if (tbody) tbody.innerHTML = `<tr><td colspan="7" style="color:#f66;text-align:center;">Erro: ${err.message}</td></tr>`;
+    }
+  }
+
+  function filtrarPosicaoLocal() {
+    const q = (document.getElementById('posicaoEstoqueSearch')?.value || '').toLowerCase().trim();
+    if (!q) {
+      renderPosicaoTabela(posicaoAllDados);
+      return;
+    }
+    const filtrado = posicaoAllDados.filter(r =>
+      r.codigo.toLowerCase().includes(q) || r.descricao.toLowerCase().includes(q)
+    );
+    renderPosicaoTabela(filtrado);
+  }
+
+  function fmtNum(v) {
+    return Number(v).toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 4 });
+  }
+
+  function renderPosicaoTabela(dados) {
+    const tbody = document.getElementById('posicaoEstoqueTbody');
+    if (!tbody) return;
+    if (!dados.length) {
+      tbody.innerHTML = '<tr><td colspan="7" style="text-align:center; color:#aaa;">Nenhum item encontrado.</td></tr>';
+      return;
+    }
+    tbody.innerHTML = dados.map(r => `
+      <tr>
+        <td>${r.codigo}</td>
+        <td>${r.descricao}</td>
+        <td>${r.local_codigo}</td>
+        <td style="text-align:right;">${fmtNum(r.fisico)}</td>
+        <td style="text-align:right;">${fmtNum(r.saldo)}</td>
+        <td style="text-align:right;">${r.cmc ? fmtNum(r.cmc) : '—'}</td>
+        <td style="text-align:right;">${r.min ? fmtNum(r.min) : '—'}</td>
+      </tr>
+    `).join('');
+  }
 })();

--- a/routes/producao.js
+++ b/routes/producao.js
@@ -1,0 +1,527 @@
+// routes/producao.js
+// Integração com API IAPP (https://api.iniciativaaplicativos.com.br/api)
+// Auth: headers { token, secret } — obtidos em Engrenagem > Minha Empresa > rodapé
+// Env vars: IAPP_TOKEN, IAPP_SECRET
+const express = require('express');
+const https   = require('https');
+const { dbQuery } = require('../src/db');
+
+const router = express.Router();
+
+const IAPP_BASE = 'https://api.iniciativaaplicativos.com.br/api';
+
+/** Aguarda N milissegundos */
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Faz uma requisição GET à API IAPP.
+ * @param {string} path  ex: '/manufatura/ordens-producao/lista'
+ * @param {object} params  query string params (offset, page, filters, etc.)
+ */
+function iappGet(path, params = {}) {
+  return new Promise((resolve, reject) => {
+    const token  = process.env.IAPP_TOKEN;
+    const secret = process.env.IAPP_SECRET;
+
+    if (!token || !secret) {
+      return reject(new Error('IAPP_TOKEN e IAPP_SECRET não configurados no .env'));
+    }
+
+    const qs = new URLSearchParams(params).toString();
+    const url = new URL(`${IAPP_BASE}${path}${qs ? '?' + qs : ''}`);
+
+    const options = {
+      hostname: url.hostname,
+      path: url.pathname + url.search,
+      method: 'GET',
+      headers: {
+        'token': token,
+        'secret': secret,
+        'Content-Type': 'application/json'
+      }
+    };
+
+    const req = https.request(options, (resp) => {
+      let body = '';
+      resp.on('data', chunk => { body += chunk; });
+      resp.on('end', () => {
+        try {
+          const json = JSON.parse(body);
+          if (resp.statusCode >= 400) {
+            const err = new Error(json.message || `HTTP ${resp.statusCode}`);
+            err.status = resp.statusCode;
+            err.iappCode = json.code;
+            return reject(err);
+          }
+          resolve(json);
+        } catch (e) {
+          reject(new Error(`Resposta inválida da API IAPP: ${body.slice(0, 200)}`));
+        }
+      });
+    });
+
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+/* ---------------------------------------------------------------
+ * Garante que o schema IAPP_API e as 3 tabelas existem (idempotente)
+ * --------------------------------------------------------------- */
+async function garantirTabela() {
+  await dbQuery(`CREATE SCHEMA IF NOT EXISTS "IAPP_API"`);
+  await dbQuery(`
+    CREATE TABLE IF NOT EXISTS "IAPP_API".op_iapp_produto (
+      produto_id            INTEGER       NOT NULL PRIMARY KEY,
+      identificacao         TEXT,
+      descricao             TEXT,
+      unidade_medida        TEXT,
+      ean                   TEXT,
+      tipo                  TEXT,
+      origem                TEXT,
+      ncm                   TEXT,
+      cest                  TEXT,
+      status                TEXT,
+      valor_venda           NUMERIC(18,6),
+      valor_custo           NUMERIC(18,6),
+      lucro_pretendido      NUMERIC(18,4),
+      altura                NUMERIC(12,4),
+      largura               NUMERIC(12,4),
+      comprimento           NUMERIC(12,4),
+      peso_bruto            NUMERIC(12,4),
+      peso_liquido          NUMERIC(12,4),
+      peso_tara             NUMERIC(12,4),
+      area                  NUMERIC(12,4),
+      diametro              NUMERIC(12,4),
+      qtde_volume           NUMERIC(12,4),
+      tipo_volume           TEXT,
+      qtde_embalagem        NUMERIC(12,4),
+      tipo_embalagem        TEXT,
+      lote_minimo_compra    NUMERIC(12,4),
+      maximo_empilhamentos  NUMERIC(12,4),
+      qtde_seguranca        NUMERIC(12,4),
+      qtde_minima           NUMERIC(12,4),
+      grupo_id              INTEGER,
+      grupo_identificacao   TEXT,
+      grupo_descricao       TEXT,
+      data_ultima_atualizacao TIMESTAMP,
+      sincronizado_em       TIMESTAMP NOT NULL DEFAULT NOW()
+    );
+    CREATE INDEX IF NOT EXISTS idx_iapp_produto_ident  ON "IAPP_API".op_iapp_produto (identificacao);
+    CREATE INDEX IF NOT EXISTS idx_iapp_produto_tipo   ON "IAPP_API".op_iapp_produto (tipo);
+    CREATE INDEX IF NOT EXISTS idx_iapp_produto_status ON "IAPP_API".op_iapp_produto (status);
+
+    CREATE TABLE IF NOT EXISTS "IAPP_API".op_iapp (
+      iapp_id               INTEGER       NOT NULL PRIMARY KEY,
+      identificacao         TEXT,
+      status                TEXT,
+      produto_id            INTEGER  REFERENCES "IAPP_API".op_iapp_produto (produto_id) ON DELETE SET NULL,
+      ficha_tecnica         INTEGER,
+      linha_producao        INTEGER,
+      qtde                  NUMERIC(18,4),
+      tempo_total           NUMERIC(18,4),
+      obs                   TEXT,
+      cliente               JSONB,
+      projeto               JSONB,
+      origem                JSONB,
+      documento             JSONB,
+      data_abertura              TIMESTAMP,
+      data_inicio                TIMESTAMP,
+      data_final                 TIMESTAMP,
+      data_encerramento          TIMESTAMP,
+      data_previsao_faturamento  TIMESTAMP,
+      data_previsao_entrega      TIMESTAMP,
+      data_ultima_atualizacao    TIMESTAMP,
+      sincronizado_em       TIMESTAMP NOT NULL DEFAULT NOW()
+    );
+    CREATE INDEX IF NOT EXISTS idx_iapp_op_status          ON "IAPP_API".op_iapp (status);
+    CREATE INDEX IF NOT EXISTS idx_iapp_op_produto_id      ON "IAPP_API".op_iapp (produto_id);
+    CREATE INDEX IF NOT EXISTS idx_iapp_op_data_abertura   ON "IAPP_API".op_iapp (data_abertura DESC);
+    CREATE INDEX IF NOT EXISTS idx_iapp_op_ult_atualizacao ON "IAPP_API".op_iapp (data_ultima_atualizacao DESC);
+
+    CREATE TABLE IF NOT EXISTS "IAPP_API".op_iapp_os (
+      os_id                 INTEGER       NOT NULL PRIMARY KEY,
+      op_iapp_id            INTEGER       NOT NULL REFERENCES "IAPP_API".op_iapp (iapp_id) ON DELETE CASCADE,
+      identificacao         TEXT,
+      status                TEXT,
+      operacao              TEXT,
+      grupo_equipamentos    JSONB,
+      equipamento           JSONB,
+      projeto               JSONB,
+      tempo_total           NUMERIC(18,4),
+      data_abertura         TIMESTAMP,
+      data_inicio           TIMESTAMP,
+      data_final            TIMESTAMP,
+      data_encerramento     TIMESTAMP,
+      data_ultima_atualizacao TIMESTAMP,
+      sincronizado_em       TIMESTAMP NOT NULL DEFAULT NOW()
+    );
+    CREATE INDEX IF NOT EXISTS idx_iapp_os_op_id  ON "IAPP_API".op_iapp_os (op_iapp_id);
+    CREATE INDEX IF NOT EXISTS idx_iapp_os_status ON "IAPP_API".op_iapp_os (status);
+  `);
+}
+
+let tabelaGarantida = false;
+
+/* ---------------------------------------------------------------
+ * Upsert nas 3 tabelas (schema IAPP_API) para um lote de OPs
+ * --------------------------------------------------------------- */
+function parseTs(v) { return v || null; }
+
+async function upsertOps(ops) {
+  if (!ops.length) return;
+  for (const op of ops) {
+    const p = op.produto || {};
+
+    // 1. Upsert produto
+    if (p.id) {
+      await dbQuery(`
+        INSERT INTO "IAPP_API".op_iapp_produto (
+          produto_id, identificacao, descricao, unidade_medida, ean,
+          tipo, origem, ncm, cest, status,
+          valor_venda, valor_custo, lucro_pretendido,
+          altura, largura, comprimento, peso_bruto, peso_liquido, peso_tara, area, diametro,
+          qtde_volume, tipo_volume, qtde_embalagem, tipo_embalagem,
+          lote_minimo_compra, maximo_empilhamentos, qtde_seguranca, qtde_minima,
+          grupo_id, grupo_identificacao, grupo_descricao,
+          data_ultima_atualizacao, sincronizado_em
+        ) VALUES (
+          $1,$2,$3,$4,$5,
+          $6,$7,$8,$9,$10,
+          $11,$12,$13,
+          $14,$15,$16,$17,$18,$19,$20,$21,
+          $22,$23,$24,$25,
+          $26,$27,$28,$29,
+          $30,$31,$32,
+          $33, NOW()
+        )
+        ON CONFLICT (produto_id) DO UPDATE SET
+          identificacao        = EXCLUDED.identificacao,
+          descricao            = EXCLUDED.descricao,
+          unidade_medida       = EXCLUDED.unidade_medida,
+          ean                  = EXCLUDED.ean,
+          tipo                 = EXCLUDED.tipo,
+          origem               = EXCLUDED.origem,
+          ncm                  = EXCLUDED.ncm,
+          cest                 = EXCLUDED.cest,
+          status               = EXCLUDED.status,
+          valor_venda          = EXCLUDED.valor_venda,
+          valor_custo          = EXCLUDED.valor_custo,
+          lucro_pretendido     = EXCLUDED.lucro_pretendido,
+          altura               = EXCLUDED.altura,
+          largura              = EXCLUDED.largura,
+          comprimento          = EXCLUDED.comprimento,
+          peso_bruto           = EXCLUDED.peso_bruto,
+          peso_liquido         = EXCLUDED.peso_liquido,
+          peso_tara            = EXCLUDED.peso_tara,
+          area                 = EXCLUDED.area,
+          diametro             = EXCLUDED.diametro,
+          qtde_volume          = EXCLUDED.qtde_volume,
+          tipo_volume          = EXCLUDED.tipo_volume,
+          qtde_embalagem       = EXCLUDED.qtde_embalagem,
+          tipo_embalagem       = EXCLUDED.tipo_embalagem,
+          lote_minimo_compra   = EXCLUDED.lote_minimo_compra,
+          maximo_empilhamentos = EXCLUDED.maximo_empilhamentos,
+          qtde_seguranca       = EXCLUDED.qtde_seguranca,
+          qtde_minima          = EXCLUDED.qtde_minima,
+          grupo_id             = EXCLUDED.grupo_id,
+          grupo_identificacao  = EXCLUDED.grupo_identificacao,
+          grupo_descricao      = EXCLUDED.grupo_descricao,
+          data_ultima_atualizacao = EXCLUDED.data_ultima_atualizacao,
+          sincronizado_em      = NOW()
+      `, [
+        p.id, p.identificacao || null, p.descricao || null, p.unidade_medida || null, p.ean || null,
+        p.tipo || null, p.origem || null, p.ncm || null, p.cest || null, p.status || null,
+        p.valor_venda ?? null, p.valor_custo ?? null, p.lucro_pretendido ?? null,
+        p.altura ?? null, p.largura ?? null, p.comprimento ?? null,
+        p.peso_bruto ?? null, p.peso_liquido ?? null, p.peso_tara ?? null,
+        p.area ?? null, p.diametro ?? null,
+        p.qtde_volume ?? null, p.tipo_volume || null, p.qtde_embalagem ?? null, p.tipo_embalagem || null,
+        p.lote_minimo_compra ?? null, p.maximo_empilhamentos ?? null,
+        p.qtde_seguranca ?? null, p.qtde_minima ?? null,
+        p.grupo?.id || null, p.grupo?.identificacao || null, p.grupo?.descricao || null,
+        parseTs(p.data_ultima_atualizacao)
+      ]);
+    }
+
+    // 2. Upsert OP
+    await dbQuery(`
+      INSERT INTO "IAPP_API".op_iapp (
+        iapp_id, identificacao, status,
+        produto_id, ficha_tecnica, linha_producao,
+        qtde, tempo_total, obs,
+        cliente, projeto, origem, documento,
+        data_abertura, data_inicio, data_final, data_encerramento,
+        data_previsao_faturamento, data_previsao_entrega, data_ultima_atualizacao,
+        sincronizado_em
+      ) VALUES (
+        $1,$2,$3,
+        $4,$5,$6,
+        $7,$8,$9,
+        $10,$11,$12,$13,
+        $14,$15,$16,$17,
+        $18,$19,$20,
+        NOW()
+      )
+      ON CONFLICT (iapp_id) DO UPDATE SET
+        identificacao         = EXCLUDED.identificacao,
+        status                = EXCLUDED.status,
+        produto_id            = EXCLUDED.produto_id,
+        ficha_tecnica         = EXCLUDED.ficha_tecnica,
+        linha_producao        = EXCLUDED.linha_producao,
+        qtde                  = EXCLUDED.qtde,
+        tempo_total           = EXCLUDED.tempo_total,
+        obs                   = EXCLUDED.obs,
+        cliente               = EXCLUDED.cliente,
+        projeto               = EXCLUDED.projeto,
+        origem                = EXCLUDED.origem,
+        documento             = EXCLUDED.documento,
+        data_abertura              = EXCLUDED.data_abertura,
+        data_inicio                = EXCLUDED.data_inicio,
+        data_final                 = EXCLUDED.data_final,
+        data_encerramento          = EXCLUDED.data_encerramento,
+        data_previsao_faturamento  = EXCLUDED.data_previsao_faturamento,
+        data_previsao_entrega      = EXCLUDED.data_previsao_entrega,
+        data_ultima_atualizacao    = EXCLUDED.data_ultima_atualizacao,
+        sincronizado_em            = NOW()
+    `, [
+      op.id, op.identificacao, op.status,
+      p.id || null, op.ficha_tecnica || null, op.linha_producao || null,
+      op.qtde ?? null, op.tempo_total ?? null, op.obs || null,
+      op.cliente ? JSON.stringify(op.cliente) : null,
+      op.projeto ? JSON.stringify(op.projeto) : null,
+      op.origem  ? JSON.stringify(op.origem)  : null,
+      op.documento ? JSON.stringify(op.documento) : null,
+      parseTs(op.data_abertura), parseTs(op.data_inicio), parseTs(op.data_final),
+      parseTs(op.data_encerramento), parseTs(op.data_previsao_faturamento),
+      parseTs(op.data_previsao_entrega), parseTs(op.data_ultima_atualizacao)
+    ]);
+
+    // 3. Upsert OSs (ordens de serviço)
+    const oss = Array.isArray(op.ordens_servico) ? op.ordens_servico : [];
+    for (const os of oss) {
+      await dbQuery(`
+        INSERT INTO "IAPP_API".op_iapp_os (
+          os_id, op_iapp_id, identificacao, status, operacao,
+          grupo_equipamentos, equipamento, projeto, tempo_total,
+          data_abertura, data_inicio, data_final, data_encerramento,
+          data_ultima_atualizacao, sincronizado_em
+        ) VALUES (
+          $1,$2,$3,$4,$5,
+          $6,$7,$8,$9,
+          $10,$11,$12,$13,
+          $14, NOW()
+        )
+        ON CONFLICT (os_id) DO UPDATE SET
+          op_iapp_id         = EXCLUDED.op_iapp_id,
+          identificacao      = EXCLUDED.identificacao,
+          status             = EXCLUDED.status,
+          operacao           = EXCLUDED.operacao,
+          grupo_equipamentos = EXCLUDED.grupo_equipamentos,
+          equipamento        = EXCLUDED.equipamento,
+          projeto            = EXCLUDED.projeto,
+          tempo_total        = EXCLUDED.tempo_total,
+          data_abertura      = EXCLUDED.data_abertura,
+          data_inicio        = EXCLUDED.data_inicio,
+          data_final         = EXCLUDED.data_final,
+          data_encerramento  = EXCLUDED.data_encerramento,
+          data_ultima_atualizacao = EXCLUDED.data_ultima_atualizacao,
+          sincronizado_em    = NOW()
+      `, [
+        os.id, op.id, os.identificacao || null, os.status || null, os.operacao || null,
+        os.grupo_equipamentos ? JSON.stringify(os.grupo_equipamentos) : null,
+        os.equipamento        ? JSON.stringify(os.equipamento)        : null,
+        os.projeto            ? JSON.stringify(os.projeto)            : null,
+        os.tempo_total ?? null,
+        parseTs(os.data_abertura), parseTs(os.data_inicio), parseTs(os.data_final),
+        parseTs(os.data_encerramento), parseTs(os.data_ultima_atualizacao)
+      ]);
+    }
+  }
+}
+
+/* ---------------------------------------------------------------
+ * syncEncerradosBackground()
+ * Busca OPs com status ENCERRADO no IAPP e persiste no DB (schema IAPP_API).
+ * Usa smart-stop: se uma página inteira já está no DB como ENCERRADO,
+ * as páginas mais antigas também estão → para a paginação.
+ * Chamada automaticamente após cada GET /ordens (setImmediate).
+ * --------------------------------------------------------------- */
+let syncEncerradosEmAndamento = false;
+
+async function syncEncerradosBackground() {
+  if (syncEncerradosEmAndamento) return;
+  syncEncerradosEmAndamento = true;
+
+  try {
+    if (!tabelaGarantida) {
+      await garantirTabela();
+      tabelaGarantida = true;
+    }
+
+    const OFFSET    = 100;
+    const INTERVALO = Math.ceil(1000 / 3); // 3 req/s
+
+    // Carrega encerrados já no DB para evitar upserts desnecessários
+    let encerradosNoDb = new Set();
+    try {
+      const r = await dbQuery(`SELECT iapp_id FROM "IAPP_API".op_iapp WHERE status = 'ENCERRADO'`);
+      encerradosNoDb = new Set(r.rows.map(row => row.iapp_id));
+    } catch (e) {
+      console.warn('[producao] syncEncerrados: não foi possível carregar cache:', e.message);
+    }
+
+    let page = 1;
+    let totalUpserted = 0;
+
+    while (true) {
+      if (page > 1) await sleep(INTERVALO);
+      const r = await iappGet('/manufatura/ordens-producao/lista', {
+        offset:    OFFSET,
+        sort_by:   'data_abertura',
+        sort_type: 'DESC',
+        status:    'ENCERRADO',
+        page
+      });
+      const records = Array.isArray(r.response) ? r.response : [];
+      if (records.length === 0) break;
+
+      // Smart-stop: se todos nesta página já estão no DB → para
+      if (records.every(op => encerradosNoDb.has(op.id))) {
+        console.log(`[producao] syncEncerrados: página ${page} toda cacheada — encerrando.`);
+        break;
+      }
+
+      // Upsert apenas os ainda não cacheados
+      const paraUpsert = records.filter(op => !encerradosNoDb.has(op.id));
+      if (paraUpsert.length > 0) {
+        await upsertOps(paraUpsert);
+        totalUpserted += paraUpsert.length;
+      }
+
+      if (records.length < OFFSET) break;
+      page++;
+    }
+
+    console.log(`[producao] syncEncerrados concluído: ${totalUpserted} upsertados em IAPP_API.`);
+  } catch (err) {
+    console.error('[producao] Erro no sync ENCERRADOS:', err.message);
+  } finally {
+    syncEncerradosEmAndamento = false;
+  }
+}
+
+/* ---------------------------------------------------------------
+ * GET /api/producao/ordens
+ * Busca DIRETAMENTE do IAPP com filtro status=A PRODUZIR (dado sempre preciso).
+ * Após responder ao cliente, dispara sync de ENCERRADOS em background.
+ * --------------------------------------------------------------- */
+router.get('/ordens', async (req, res) => {
+  try {
+    if (!tabelaGarantida) {
+      await garantirTabela();
+      tabelaGarantida = true;
+    }
+
+    if (!process.env.IAPP_TOKEN || !process.env.IAPP_SECRET) {
+      return res.status(500).json({ error: 'IAPP_TOKEN e IAPP_SECRET não configurados.' });
+    }
+
+    const OFFSET    = 100;
+    const INTERVALO = Math.ceil(1000 / 3); // 3 req/s
+
+    // Busca todas as páginas com status A PRODUZIR direto do IAPP
+    const todasOPs = [];
+    let page = 1;
+    while (true) {
+      if (page > 1) await sleep(INTERVALO);
+      const r = await iappGet('/manufatura/ordens-producao/lista', {
+        offset:    OFFSET,
+        sort_by:   'data_abertura',
+        sort_type: 'DESC',
+        status:    'A PRODUZIR',
+        page
+      });
+      const records = Array.isArray(r.response) ? r.response : [];
+      // Filtra client-side como segurança caso a API ignore o filtro
+      const ativas = records.filter(op => op.status === 'A PRODUZIR');
+      todasOPs.push(...ativas);
+      if (records.length < OFFSET) break;
+      page++;
+    }
+
+    console.log(`[producao] IAPP live: ${todasOPs.length} ordens "A PRODUZIR" em ${page} página(s).`);
+
+    // Normaliza a estrutura esperada pelo front
+    const agora = new Date().toISOString();
+    const ordens = todasOPs.map(op => ({
+      id:                        op.id,
+      identificacao:             op.identificacao,
+      status:                    op.status,
+      qtde:                      op.qtde,
+      tempo_total:               op.tempo_total,
+      ficha_tecnica:             op.ficha_tecnica,
+      linha_producao:            op.linha_producao,
+      obs:                       op.obs,
+      cliente:                   op.cliente,
+      projeto:                   op.projeto,
+      origem:                    op.origem,
+      documento:                 op.documento,
+      data_abertura:             op.data_abertura,
+      data_inicio:               op.data_inicio,
+      data_final:                op.data_final,
+      data_encerramento:         op.data_encerramento,
+      data_previsao_faturamento: op.data_previsao_faturamento,
+      data_previsao_entrega:     op.data_previsao_entrega,
+      data_ultima_atualizacao:   op.data_ultima_atualizacao,
+      sincronizado_em:           agora,
+      produto: op.produto ? {
+        id:            op.produto.id,
+        identificacao: op.produto.identificacao,
+        descricao:     op.produto.descricao,
+        tipo:          op.produto.tipo,
+        valor_custo:   op.produto.valor_custo,
+        valor_venda:   op.produto.valor_venda,
+        unidade_medida:op.produto.unidade_medida,
+        status:        op.produto.status
+      } : null,
+      ordens_servico: Array.isArray(op.ordens_servico) ? op.ordens_servico.map(os => ({
+        id:               os.id,
+        identificacao:    os.identificacao,
+        status:           os.status,
+        operacao:         os.operacao,
+        tempo_total:      os.tempo_total,
+        data_abertura:    os.data_abertura,
+        data_inicio:      os.data_inicio,
+        data_final:       os.data_final,
+        data_encerramento:os.data_encerramento
+      })) : []
+    }));
+
+    // Responde ao usuário e em background atualiza ENCERRADOS no DB
+    setImmediate(() => syncEncerradosBackground());
+
+    return res.json({
+      success:          true,
+      total_consultado: ordens.length,
+      total_ativas:     ordens.length,
+      ordens,
+      sincronizado_em:  agora
+    });
+  } catch (err) {
+    console.error('[producao] Erro ao buscar ordens do IAPP:', err.message);
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+/* ---------------------------------------------------------------
+ * POST /api/producao/sync
+ * Força sincronização manual de ENCERRADOS no DB (uso administrativo).
+ * --------------------------------------------------------------- */
+router.post('/sync', async (req, res) => {
+  setImmediate(() => syncEncerradosBackground());
+  return res.json({ success: true, message: 'Sync de ENCERRADOS iniciado em background.' });
+});
+
+module.exports = router;
+

--- a/server.js
+++ b/server.js
@@ -227,6 +227,7 @@ app.use('/api/qualidade', require('./routes/qualidadeFotos'));
 app.use('/api/registros', require('./routes/registros'));
 app.use('/api/sac', require('./routes/sacEnvios'));
 app.use('/api/ai', require('./routes/ai_assistant'));
+app.use('/api/producao', require('./routes/producao'));
 
 app.get('/api/produtos/stream', (req, res) => {
   const accept = String(req.headers?.accept || '');
@@ -12866,6 +12867,78 @@ app.post('/api/armazem/almoxarifado', express.json(), async (req, res) => {
   } catch (err) {
     console.error('[almoxarifado SQL]', err);
     res.status(500).json({ ok:false, error:String(err.message || err) });
+  }
+});
+
+// ── GET /api/estoque/posicao-por-data ──────────────────────────────────────
+// Retorna posição de estoque para uma data específica
+// Query params: data (YYYY-MM-DD), pagina (opcional), limite (opcional)
+app.get('/api/estoque/posicao-por-data', async (req, res) => {
+  try {
+    const { data, pagina = 1, limite = 200 } = req.query;
+    if (!data || !/^\d{4}-\d{2}-\d{2}$/.test(data)) {
+      return res.status(400).json({ ok: false, error: 'Parâmetro data inválido (use YYYY-MM-DD).' });
+    }
+    const pg = Math.max(1, parseInt(pagina) || 1);
+    const lim = Math.min(500, Math.max(1, parseInt(limite) || 200));
+    const offset = (pg - 1) * lim;
+
+    const { rows: countRows } = await pool.query(`
+      SELECT COUNT(*) AS total
+      FROM public.omie_estoque_posicao
+      WHERE data_posicao = $1
+    `, [data]);
+    const total = parseInt(countRows[0].total) || 0;
+
+    const { rows } = await pool.query(`
+      SELECT
+        p.codigo,
+        p.descricao,
+        p.local_codigo,
+        p.fisico,
+        p.saldo,
+        p.cmc,
+        p.estoque_minimo
+      FROM public.omie_estoque_posicao p
+      WHERE p.data_posicao = $1
+      ORDER BY p.descricao NULLS LAST, p.codigo
+      LIMIT $2 OFFSET $3
+    `, [data, lim, offset]);
+
+    const dados = rows.map(r => ({
+      codigo       : r.codigo        || '',
+      descricao    : r.descricao     || '',
+      local_codigo : r.local_codigo  || '',
+      fisico       : Number(r.fisico)        || 0,
+      saldo        : Number(r.saldo)         || 0,
+      cmc          : Number(r.cmc)           || 0,
+      min          : Number(r.estoque_minimo) || 0,
+    }));
+
+    res.json({ ok: true, data, pagina: pg, totalRegistros: total, totalPaginas: Math.ceil(total / lim), dados });
+  } catch (err) {
+    console.error('[posicao-por-data SQL]', err);
+    res.status(500).json({ ok: false, error: String(err.message || err) });
+  }
+});
+
+// ── GET /api/estoque/datas-disponiveis ──────────────────────────────────────
+// Retorna datas distintas que existem na tabela omie_estoque_posicao
+app.get('/api/estoque/datas-disponiveis', async (req, res) => {
+  try {
+    const { rows } = await pool.query(`
+      SELECT DISTINCT data_posicao
+      FROM public.omie_estoque_posicao
+      ORDER BY data_posicao DESC
+      LIMIT 365
+    `);
+    const datas = rows.map(r => r.data_posicao instanceof Date
+      ? r.data_posicao.toISOString().slice(0, 10)
+      : String(r.data_posicao).slice(0, 10));
+    res.json({ ok: true, datas });
+  } catch (err) {
+    console.error('[datas-disponiveis SQL]', err);
+    res.status(500).json({ ok: false, error: String(err.message || err) });
   }
 });
 

--- a/sql/create_op_iapp.sql
+++ b/sql/create_op_iapp.sql
@@ -1,0 +1,151 @@
+-- =============================================================
+-- Cache de Ordens de Produção — API IAPP
+-- Schema: IAPP_API  (separado do schema public)
+--
+--   op_iapp_produto   Cadastro de produtos (1 linha por produto único)
+--   op_iapp           Ordens de Produção   (N OPs por produto)
+--   op_iapp_os        Ordens de Serviço    (N OSs por OP)
+--
+-- Populado via POST /api/producao/sync (manual/agendado)
+-- Leitura via GET  /api/producao/ordens (sem sync automático)
+-- =============================================================
+
+CREATE SCHEMA IF NOT EXISTS "IAPP_API";
+
+-- -------------------------------------------------------------
+-- 1. PRODUTOS
+-- -------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS "IAPP_API".op_iapp_produto (
+  produto_id            INTEGER       NOT NULL PRIMARY KEY,  -- produto.id
+  identificacao         TEXT,                                -- produto.identificacao (código)
+  descricao             TEXT,                                -- produto.descricao
+  unidade_medida        TEXT,                                -- produto.unidade_medida
+  ean                   TEXT,                                -- produto.ean
+  tipo                  TEXT,                                -- produto.tipo
+  origem                TEXT,                                -- produto.origem
+  ncm                   TEXT,                                -- produto.ncm
+  cest                  TEXT,                                -- produto.cest
+  status                TEXT,                                -- produto.status ("ativo" etc.)
+
+  -- Valores
+  valor_venda           NUMERIC(18,6),
+  valor_custo           NUMERIC(18,6),
+  lucro_pretendido      NUMERIC(18,4),
+
+  -- Dimensões / peso
+  altura                NUMERIC(12,4),
+  largura               NUMERIC(12,4),
+  comprimento           NUMERIC(12,4),
+  peso_bruto            NUMERIC(12,4),
+  peso_liquido          NUMERIC(12,4),
+  peso_tara             NUMERIC(12,4),
+  area                  NUMERIC(12,4),
+  diametro              NUMERIC(12,4),
+
+  -- Embalagem / estoque
+  qtde_volume           NUMERIC(12,4),
+  tipo_volume           TEXT,
+  qtde_embalagem        NUMERIC(12,4),
+  tipo_embalagem        TEXT,
+  lote_minimo_compra    NUMERIC(12,4),
+  maximo_empilhamentos  NUMERIC(12,4),
+  qtde_seguranca        NUMERIC(12,4),
+  qtde_minima           NUMERIC(12,4),
+
+  -- Grupo / classificação
+  grupo_id              INTEGER,
+  grupo_identificacao   TEXT,
+  grupo_descricao       TEXT,
+
+  -- Datas
+  data_ultima_atualizacao  TIMESTAMP,
+
+  -- Controle
+  sincronizado_em  TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_iapp_produto_ident  ON "IAPP_API".op_iapp_produto (identificacao);
+CREATE INDEX IF NOT EXISTS idx_iapp_produto_tipo   ON "IAPP_API".op_iapp_produto (tipo);
+CREATE INDEX IF NOT EXISTS idx_iapp_produto_status ON "IAPP_API".op_iapp_produto (status);
+
+
+-- -------------------------------------------------------------
+-- 2. ORDENS DE PRODUÇÃO (item pai)
+-- Chave: id da OP no IAPP.
+-- -------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS "IAPP_API".op_iapp (
+  iapp_id               INTEGER       NOT NULL PRIMARY KEY,  -- OP.id
+  identificacao         TEXT,                                -- ex: "0002394"
+  status                TEXT,                                -- "A PRODUZIR", "PRODUZINDO", "ENCERRADO" …
+
+  -- Referências
+  produto_id            INTEGER  REFERENCES "IAPP_API".op_iapp_produto (produto_id) ON DELETE SET NULL,
+  ficha_tecnica         INTEGER,                             -- id da ficha técnica no IAPP
+  linha_producao        INTEGER,                             -- id da linha de produção no IAPP
+
+  -- Quantidades
+  qtde                  NUMERIC(18,4),
+  tempo_total           NUMERIC(18,4),
+
+  -- Observações e links opcionais (mantidos como JSONB pois variam)
+  obs                   TEXT,
+  cliente               JSONB,   -- objeto cliente quando vinculado
+  projeto               JSONB,   -- objeto projeto quando vinculado
+  origem                JSONB,   -- origem da OP
+  documento             JSONB,   -- documento vinculado
+
+  -- Datas
+  data_abertura              TIMESTAMP,
+  data_inicio                TIMESTAMP,
+  data_final                 TIMESTAMP,
+  data_encerramento          TIMESTAMP,
+  data_previsao_faturamento  TIMESTAMP,
+  data_previsao_entrega      TIMESTAMP,
+  data_ultima_atualizacao    TIMESTAMP,
+
+  -- Controle
+  sincronizado_em  TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_iapp_op_status          ON "IAPP_API".op_iapp (status);
+CREATE INDEX IF NOT EXISTS idx_iapp_op_produto_id      ON "IAPP_API".op_iapp (produto_id);
+CREATE INDEX IF NOT EXISTS idx_iapp_op_data_abertura   ON "IAPP_API".op_iapp (data_abertura DESC);
+CREATE INDEX IF NOT EXISTS idx_iapp_op_ult_atualizacao ON "IAPP_API".op_iapp (data_ultima_atualizacao DESC);
+
+
+-- -------------------------------------------------------------
+-- 3. ORDENS DE SERVIÇO (itens filhos da OP)
+-- Chave: id da OS no IAPP.
+-- -------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS "IAPP_API".op_iapp_os (
+  os_id                 INTEGER       NOT NULL PRIMARY KEY,  -- OS.id
+  op_iapp_id            INTEGER       NOT NULL REFERENCES "IAPP_API".op_iapp (iapp_id) ON DELETE CASCADE,
+
+  identificacao         TEXT,   -- ex: "0002394.01"
+  status                TEXT,   -- "ABERTA", "EM ANDAMENTO", "ENCERRADA" …
+  operacao              TEXT,   -- nome da operação ("MONTAGEM", "TESTE FINAL" …)
+
+  -- Equipamento
+  grupo_equipamentos    JSONB,
+  equipamento           JSONB,
+
+  -- Projeto vinculado
+  projeto               JSONB,
+
+  -- Tempo
+  tempo_total           NUMERIC(18,4),
+
+  -- Datas
+  data_abertura         TIMESTAMP,
+  data_inicio           TIMESTAMP,
+  data_final            TIMESTAMP,
+  data_encerramento     TIMESTAMP,
+  data_ultima_atualizacao TIMESTAMP,
+
+  -- Controle
+  sincronizado_em  TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_iapp_os_op_id  ON "IAPP_API".op_iapp_os (op_iapp_id);
+CREATE INDEX IF NOT EXISTS idx_iapp_os_status ON "IAPP_API".op_iapp_os (status);
+


### PR DESCRIPTION
## Resumo
3 commits temáticos:

- `feat(producao)`: novo módulo `routes/producao.js` + migration `sql/create_op_iapp.sql`
- `feat(producao)`: monta rota `/api/producao` em `server.js`; adiciona menus de Produção e endpoint `GET /api/estoque/posicao-por-data` em `menu_produto.html/js`
- `fix(login)`: guarda `if (!overlay) return` em `login/login.js` para páginas standalone

## Validação local
- `node --check` em todos os arquivos JS alterados: OK
- `pm2 restart intranet_api`: online