### PR TITLE
feat(estoque+producao): snapshot diario de estoque e melhorias no kanban de producao

### DIFF
--- a/.github/instructions/novo-item-menu-lateral.instructions.md
+++ b/.github/instructions/novo-item-menu-lateral.instructions.md
@@ -1,0 +1,78 @@
+---
+applyTo: 'menu_produto.html'
+---
+# Protocolo obrigatório ao adicionar novo item no menu lateral
+
+Sempre que você adicionar um novo `<a>` com `data-nav-key` e `data-nav-selector` no menu lateral (`menu_produto.html`), **execute imediatamente** o script abaixo para registrar o item no banco e liberar apenas para admins:
+
+```js
+// Substituir os valores entre < > conforme o novo item
+const NAV_KEY      = 'side:<area>:<nome>';   // ex: 'side:producao:montagem'
+const NAV_LABEL    = '<Label visível>';       // ex: 'Produção montagem'
+const NAV_SELECTOR = '#<id-do-elemento>';    // ex: '#menu-monta-producao'
+const PARENT_KEY   = 'side:<area>';          // ex: 'side:producao'
+const NAV_SORT     = 99;                     // número de ordem (alto = fim da lista)
+
+require('dotenv').config();
+const { Pool } = require('pg');
+const pool = new Pool({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false } });
+
+(async () => {
+  // 1. Busca o id do nó pai
+  const { rows: [parent] } = await pool.query(
+    `SELECT id FROM public.nav_node WHERE key = $1`, [PARENT_KEY]
+  );
+  if (!parent) throw new Error(`Nó pai "${PARENT_KEY}" não encontrado`);
+
+  // 2. Insere (ou atualiza) o nav_node
+  const { rows: [node] } = await pool.query(`
+    INSERT INTO public.nav_node (key, label, position, parent_id, sort, active, selector)
+    VALUES ($1, $2, 'side', $3, $4, true, $5)
+    ON CONFLICT (key) DO UPDATE SET
+      label    = EXCLUDED.label,
+      active   = true,
+      selector = EXCLUDED.selector
+    RETURNING id, key
+  `, [NAV_KEY, NAV_LABEL, parent.id, NAV_SORT, NAV_SELECTOR]);
+  console.log('nav_node OK:', node);
+
+  // 3. Permissão por role: admin=true, todos os outros=false
+  const { rows: roles } = await pool.query(
+    `SELECT DISTINCT role FROM public.auth_role_permission`
+  );
+  const allRoles = [...new Set([...roles.map(r => r.role), 'admin', 'editor'])];
+  for (const role of allRoles) {
+    await pool.query(`
+      INSERT INTO public.auth_role_permission (role, node_id, allow)
+      VALUES ($1, $2, $3)
+      ON CONFLICT (role, node_id) DO UPDATE SET allow = EXCLUDED.allow
+    `, [role, node.id, role === 'admin']);
+  }
+  console.log('auth_role_permission OK');
+
+  // 4. Permissão por usuário: allow = (roles contém 'admin')
+  const { rows: users } = await pool.query(
+    `SELECT id, roles FROM public.auth_user`
+  );
+  for (const u of users) {
+    const isAdmin = Array.isArray(u.roles) && u.roles.includes('admin');
+    await pool.query(`
+      INSERT INTO public.auth_user_permission (user_id, node_id, allow)
+      VALUES ($1, $2, $3)
+      ON CONFLICT (user_id, node_id) DO UPDATE SET allow = EXCLUDED.allow
+    `, [u.id, node.id, isAdmin]);
+  }
+  console.log('auth_user_permission OK — admins liberados, demais bloqueados');
+
+  pool.end();
+})().catch(e => { console.error(e); process.exit(1); });
+```
+
+**Regras:**
+- O item ficará **visível apenas para usuários com `role = 'admin'`** — os demais vêem o item oculto.
+- Para liberar para outros usuários, use a tela de gerenciamento de permissões da intranet.
+- **Não é necessário reiniciar o PM2** — permissões são consultadas em tempo real.
+- O usuário deve dar **F5** no browser para invalidar o cache `perm-tree` do localStorage.
+
+## Por que isso é necessário
+A função SQL `auth_user_permissions_tree` usa `ELSE FALSE` como padrão — itens sem registro em `nav_node` ficam invisíveis para todos, e itens sem registro em `auth_role_permission`/`auth_user_permission` ficam ocultos para não-admins.

--- a/cron/snapshot_estoque_diario.js
+++ b/cron/snapshot_estoque_diario.js
@@ -1,0 +1,112 @@
+/**
+ * ============================================================
+ * CRON — Snapshot diário de estoque (20:00 horário Brasília)
+ * ============================================================
+ * Copia o estado atual de logistica.estoque_atual para
+ * public.omie_estoque_posicao com data_posicao = hoje.
+ *
+ * Não faz nenhuma chamada à API Omie — usa apenas dados
+ * locais já mantidos pelo webhook.
+ *
+ * Isso garante que a aba "Posição de Estoque por Data" tenha
+ * um registro diário fiel do fechamento de cada dia.
+ */
+
+const { dbQuery } = require('../src/db');
+
+const TAG = '[SnapshotEstoque]';
+
+// Horário de Brasília = UTC-3 → 20:00 BRT = 23:00 UTC
+// Usamos getHours() que já respeita o fuso do servidor (Linux configurado como America/Sao_Paulo)
+const HORA_ALVO  = 20; // 20:00
+const MINUTO_MAX = 4;  // janela de 5 minutos (20:00 – 20:04)
+
+let _lastRunDate = null;
+
+/**
+ * Insere/atualiza snapshot de hoje em omie_estoque_posicao
+ * copiando tudo de logistica.estoque_atual.
+ */
+async function executarSnapshotEstoque() {
+  const hoje = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+  console.log(TAG, `Iniciando snapshot de estoque para data ${hoje}...`);
+
+  try {
+    const result = await dbQuery(`
+      INSERT INTO public.omie_estoque_posicao (
+        data_posicao,
+        ingested_at,
+        local_codigo,
+        omie_prod_id,
+        cod_int,
+        codigo,
+        descricao,
+        preco_unitario,
+        saldo,
+        cmc,
+        pendente,
+        estoque_minimo,
+        reservado,
+        fisico
+      )
+      SELECT
+        $1::date           AS data_posicao,
+        now()              AS ingested_at,
+        local_codigo,
+        omie_prod_id,
+        cod_int,
+        codigo,
+        descricao,
+        preco_unitario,
+        saldo,
+        cmc,
+        pendente,
+        estoque_minimo,
+        reservado,
+        fisico
+      FROM logistica.estoque_atual
+      WHERE codigo IS NOT NULL AND codigo <> ''
+      ON CONFLICT ON CONSTRAINT uq_posicao_uni
+      DO UPDATE SET
+        descricao      = EXCLUDED.descricao,
+        preco_unitario = EXCLUDED.preco_unitario,
+        saldo          = EXCLUDED.saldo,
+        cmc            = EXCLUDED.cmc,
+        pendente       = EXCLUDED.pendente,
+        estoque_minimo = EXCLUDED.estoque_minimo,
+        reservado      = EXCLUDED.reservado,
+        fisico         = EXCLUDED.fisico,
+        ingested_at    = now()
+    `, [hoje]);
+
+    const count = result?.rowCount ?? '?';
+    console.log(TAG, `Snapshot concluído: ${count} registros gravados para ${hoje}.`);
+  } catch (err) {
+    console.error(TAG, 'Erro ao gravar snapshot:', err?.message || err);
+  }
+}
+
+function verificarHorarioSnapshot() {
+  const now    = new Date();
+  const hoje   = now.toISOString().slice(0, 10);
+  const hora   = now.getHours();
+  const minuto = now.getMinutes();
+
+  if (hora === HORA_ALVO && minuto <= MINUTO_MAX && _lastRunDate !== hoje) {
+    _lastRunDate = hoje; // evita duplo disparo dentro da janela
+    executarSnapshotEstoque().catch(err =>
+      console.error(TAG, 'Erro não tratado:', err?.message || err)
+    );
+  }
+}
+
+function iniciarCronSnapshotEstoque() {
+  console.log(TAG, `Timer iniciado — snapshot diário às ${HORA_ALVO}:00 (Brasília).`);
+  setInterval(verificarHorarioSnapshot, 60 * 1000); // verifica a cada minuto
+  verificarHorarioSnapshot(); // checa imediatamente (útil se servidor reiniciou nessa janela)
+}
+
+module.exports = {
+  iniciarCronSnapshotEstoque,
+  executarSnapshotEstoque, // exportado para permitir disparo manual via endpoint se necessário
+};

--- a/routes/producao.js
+++ b/routes/producao.js
@@ -412,104 +412,109 @@ async function syncEncerradosBackground() {
 }
 
 /* ---------------------------------------------------------------
+ * fromDb(onlyMontagem)
+ * Lê ordens do cache DB (rápido). Usado na carga inicial do kanban.
+ * onlyMontagem=false → status='A PRODUZIR'
+ * onlyMontagem=true  → status!='ENCERRADO' + produto.tipo='04 - Produto Acabado'
+ * --------------------------------------------------------------- */
+async function fromDb(onlyMontagem = false) {
+  const whereExtra = onlyMontagem
+    ? `AND op.status != 'ENCERRADO' AND TRIM(COALESCE(p.tipo,'')) = '04 - Produto Acabado'`
+    : `AND op.status = 'A PRODUZIR'`;
+
+  const { rows } = await dbQuery(`
+    SELECT
+      op.iapp_id                         AS id,
+      op.identificacao,
+      op.status,
+      op.qtde::text                      AS qtde,
+      op.tempo_total,
+      op.ficha_tecnica,
+      op.linha_producao,
+      op.obs,
+      op.cliente,
+      op.projeto,
+      op.origem,
+      op.documento,
+      op.data_abertura::text             AS data_abertura,
+      op.data_inicio::text               AS data_inicio,
+      op.data_final::text                AS data_final,
+      op.data_encerramento::text         AS data_encerramento,
+      op.data_previsao_faturamento::text AS data_previsao_faturamento,
+      op.data_previsao_entrega::text     AS data_previsao_entrega,
+      op.data_ultima_atualizacao::text   AS data_ultima_atualizacao,
+      op.sincronizado_em::text           AS sincronizado_em,
+      CASE WHEN p.produto_id IS NOT NULL THEN json_build_object(
+        'id',             p.produto_id,
+        'identificacao',  p.identificacao,
+        'descricao',      p.descricao,
+        'tipo',           p.tipo,
+        'valor_custo',    p.valor_custo::text,
+        'valor_venda',    p.valor_venda::text,
+        'unidade_medida', p.unidade_medida,
+        'status',         p.status
+      ) ELSE NULL END AS produto,
+      COALESCE(
+        json_agg(json_build_object(
+          'id',                os.os_id,
+          'identificacao',     os.identificacao,
+          'status',            os.status,
+          'operacao',          os.operacao,
+          'tempo_total',       os.tempo_total::text,
+          'data_abertura',     os.data_abertura::text,
+          'data_inicio',       os.data_inicio::text,
+          'data_final',        os.data_final::text,
+          'data_encerramento', os.data_encerramento::text
+        ) ORDER BY os.os_id) FILTER (WHERE os.os_id IS NOT NULL),
+        '[]'::json
+      ) AS ordens_servico
+    FROM "IAPP_API".op_iapp op
+    LEFT JOIN "IAPP_API".op_iapp_produto p  ON p.produto_id  = op.produto_id
+    LEFT JOIN "IAPP_API".op_iapp_os      os ON os.op_iapp_id = op.iapp_id
+    WHERE 1=1 ${whereExtra}
+    GROUP BY
+      op.iapp_id, op.identificacao, op.status, op.qtde, op.tempo_total,
+      op.ficha_tecnica, op.linha_producao, op.obs, op.cliente, op.projeto,
+      op.origem, op.documento, op.data_abertura, op.data_inicio, op.data_final,
+      op.data_encerramento, op.data_previsao_faturamento, op.data_previsao_entrega,
+      op.data_ultima_atualizacao, op.sincronizado_em,
+      p.produto_id, p.identificacao, p.descricao, p.tipo,
+      p.valor_custo, p.valor_venda, p.unidade_medida, p.status
+    ORDER BY op.data_abertura DESC NULLS LAST
+  `);
+  return rows;
+}
+
+/* ---------------------------------------------------------------
  * GET /api/producao/ordens
- * Busca DIRETAMENTE do IAPP com filtro status=A PRODUZIR (dado sempre preciso).
- * Após responder ao cliente, dispara sync de ENCERRADOS em background.
+ * Carga rápida do cache DB. Front chama /sync-ativas em seguida.
  * --------------------------------------------------------------- */
 router.get('/ordens', async (req, res) => {
   try {
-    if (!tabelaGarantida) {
-      await garantirTabela();
-      tabelaGarantida = true;
-    }
-
-    if (!process.env.IAPP_TOKEN || !process.env.IAPP_SECRET) {
-      return res.status(500).json({ error: 'IAPP_TOKEN e IAPP_SECRET não configurados.' });
-    }
-
-    const OFFSET    = 100;
-    const INTERVALO = Math.ceil(1000 / 3); // 3 req/s
-
-    // Busca todas as páginas com status A PRODUZIR direto do IAPP
-    const todasOPs = [];
-    let page = 1;
-    while (true) {
-      if (page > 1) await sleep(INTERVALO);
-      const r = await iappGet('/manufatura/ordens-producao/lista', {
-        offset:    OFFSET,
-        sort_by:   'data_abertura',
-        sort_type: 'DESC',
-        status:    'A PRODUZIR',
-        page
-      });
-      const records = Array.isArray(r.response) ? r.response : [];
-      // Filtra client-side como segurança caso a API ignore o filtro
-      const ativas = records.filter(op => op.status === 'A PRODUZIR');
-      todasOPs.push(...ativas);
-      if (records.length < OFFSET) break;
-      page++;
-    }
-
-    console.log(`[producao] IAPP live: ${todasOPs.length} ordens "A PRODUZIR" em ${page} página(s).`);
-
-    // Normaliza a estrutura esperada pelo front
-    const agora = new Date().toISOString();
-    const ordens = todasOPs.map(op => ({
-      id:                        op.id,
-      identificacao:             op.identificacao,
-      status:                    op.status,
-      qtde:                      op.qtde,
-      tempo_total:               op.tempo_total,
-      ficha_tecnica:             op.ficha_tecnica,
-      linha_producao:            op.linha_producao,
-      obs:                       op.obs,
-      cliente:                   op.cliente,
-      projeto:                   op.projeto,
-      origem:                    op.origem,
-      documento:                 op.documento,
-      data_abertura:             op.data_abertura,
-      data_inicio:               op.data_inicio,
-      data_final:                op.data_final,
-      data_encerramento:         op.data_encerramento,
-      data_previsao_faturamento: op.data_previsao_faturamento,
-      data_previsao_entrega:     op.data_previsao_entrega,
-      data_ultima_atualizacao:   op.data_ultima_atualizacao,
-      sincronizado_em:           agora,
-      produto: op.produto ? {
-        id:            op.produto.id,
-        identificacao: op.produto.identificacao,
-        descricao:     op.produto.descricao,
-        tipo:          op.produto.tipo,
-        valor_custo:   op.produto.valor_custo,
-        valor_venda:   op.produto.valor_venda,
-        unidade_medida:op.produto.unidade_medida,
-        status:        op.produto.status
-      } : null,
-      ordens_servico: Array.isArray(op.ordens_servico) ? op.ordens_servico.map(os => ({
-        id:               os.id,
-        identificacao:    os.identificacao,
-        status:           os.status,
-        operacao:         os.operacao,
-        tempo_total:      os.tempo_total,
-        data_abertura:    os.data_abertura,
-        data_inicio:      os.data_inicio,
-        data_final:       os.data_final,
-        data_encerramento:os.data_encerramento
-      })) : []
-    }));
-
-    // Responde ao usuário e em background atualiza ENCERRADOS no DB
+    if (!tabelaGarantida) { await garantirTabela(); tabelaGarantida = true; }
+    const ordens = await fromDb(false);
+    const agora  = new Date().toISOString();
     setImmediate(() => syncEncerradosBackground());
-
-    return res.json({
-      success:          true,
-      total_consultado: ordens.length,
-      total_ativas:     ordens.length,
-      ordens,
-      sincronizado_em:  agora
-    });
+    return res.json({ success: true, total_consultado: ordens.length, total_ativas: ordens.length, ordens, sincronizado_em: agora, from_db: true });
   } catch (err) {
-    console.error('[producao] Erro ao buscar ordens do IAPP:', err.message);
+    console.error('[producao] Erro ao ler ordens do DB:', err.message);
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+/* ---------------------------------------------------------------
+ * GET /api/producao/ordens-montagem
+ * Carga rápida do cache DB (produto.tipo='04 - Produto Acabado').
+ * --------------------------------------------------------------- */
+router.get('/ordens-montagem', async (req, res) => {
+  try {
+    if (!tabelaGarantida) { await garantirTabela(); tabelaGarantida = true; }
+    const ordens = await fromDb(true);
+    const agora  = new Date().toISOString();
+    setImmediate(() => syncEncerradosBackground());
+    return res.json({ success: true, total_consultado: ordens.length, total_ativas: ordens.length, ordens, sincronizado_em: agora, from_db: true });
+  } catch (err) {
+    console.error('[producao] Erro ao ler montagem do DB:', err.message);
     return res.status(500).json({ error: err.message });
   }
 });
@@ -521,6 +526,73 @@ router.get('/ordens', async (req, res) => {
 router.post('/sync', async (req, res) => {
   setImmediate(() => syncEncerradosBackground());
   return res.json({ success: true, message: 'Sync de ENCERRADOS iniciado em background.' });
+});
+
+/* ---------------------------------------------------------------
+ * GET /api/producao/sync-ativas
+ * Busca registros ativos direto do IAPP, faz upsert no DB e retorna
+ * a lista atualizada. Chamado pelo front após carga rápida do DB.
+ * Query param: ?montagem=1 para painel Produção Montagem.
+ * --------------------------------------------------------------- */
+router.get('/sync-ativas', async (req, res) => {
+  const onlyMontagem = req.query.montagem === '1';
+  try {
+    if (!tabelaGarantida) { await garantirTabela(); tabelaGarantida = true; }
+
+    if (!process.env.IAPP_TOKEN || !process.env.IAPP_SECRET) {
+      return res.status(500).json({ error: 'IAPP_TOKEN e IAPP_SECRET não configurados.' });
+    }
+
+    const OFFSET    = 100;
+    const INTERVALO = Math.ceil(1000 / 3); // 3 req/s
+    const TIPO_ALVO = '04 - Produto Acabado';
+    const todasOPs  = [];
+    let   page      = 1;
+
+    if (onlyMontagem) {
+      // Todos os status (smart-stop quando página inteira ENCERRADO)
+      while (true) {
+        if (page > 1) await sleep(INTERVALO);
+        const r = await iappGet('/manufatura/ordens-producao/lista', {
+          offset: OFFSET, sort_by: 'data_abertura', sort_type: 'DESC', page
+        });
+        const records = Array.isArray(r.response) ? r.response : [];
+        if (records.length === 0) break;
+        if (records.every(op => op.status === 'ENCERRADO')) break;
+        todasOPs.push(...records.filter(op => op.status !== 'ENCERRADO'));
+        if (records.length < OFFSET) break;
+        page++;
+      }
+    } else {
+      // Somente A PRODUZIR
+      while (true) {
+        if (page > 1) await sleep(INTERVALO);
+        const r = await iappGet('/manufatura/ordens-producao/lista', {
+          offset: OFFSET, sort_by: 'data_abertura', sort_type: 'DESC', status: 'A PRODUZIR', page
+        });
+        const records = Array.isArray(r.response) ? r.response : [];
+        todasOPs.push(...records.filter(op => op.status === 'A PRODUZIR'));
+        if (records.length < OFFSET) break;
+        page++;
+      }
+    }
+
+    console.log(`[producao] sync-ativas (montagem=${onlyMontagem}): ${todasOPs.length} OPs em ${page} pág.`);
+
+    // Upsert no DB para manter cache atualizado
+    if (todasOPs.length > 0) await upsertOps(todasOPs);
+
+    // Retorna lista atualizada do DB (já inclui os recém-upsertados)
+    const ordens = await fromDb(onlyMontagem);
+    const agora  = new Date().toISOString();
+
+    setImmediate(() => syncEncerradosBackground());
+
+    return res.json({ success: true, total_consultado: ordens.length, total_ativas: ordens.length, ordens, sincronizado_em: agora, from_iapp: true });
+  } catch (err) {
+    console.error('[producao] Erro em sync-ativas:', err.message);
+    return res.status(500).json({ error: err.message });
+  }
 });
 
 module.exports = router;

--- a/scripts/backfill_estoque_posicao_2026.js
+++ b/scripts/backfill_estoque_posicao_2026.js
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+/**
+ * ============================================================================
+ * Backfill histórico de posição de estoque 2026
+ * ============================================================================
+ * Busca na API Omie (ListarPosEstoque) a posição de estoque para cada
+ * combinação (data, local) do período 01/01/2026 até ontem que ainda
+ * NÃO existe em public.omie_estoque_posicao.
+ *
+ * Pode ser interrompido e retomado — skipa automaticamente pares já gravados.
+ *
+ * USO:
+ *   node scripts/backfill_estoque_posicao_2026.js
+ *
+ *   # Limitar datas (útil para testar):
+ *   DATA_INICIO=2026-04-01 DATA_FIM=2026-04-30 node scripts/backfill_estoque_posicao_2026.js
+ *
+ * Variáveis de ambiente obrigatórias:
+ *   DATABASE_URL, OMIE_APP_KEY, OMIE_APP_SECRET
+ * ============================================================================
+ */
+
+const { Pool }          = require('pg');
+const { spawn }         = require('child_process');
+
+const DATABASE_URL    = process.env.DATABASE_URL;
+const OMIE_APP_KEY    = process.env.OMIE_APP_KEY;
+const OMIE_APP_SECRET = process.env.OMIE_APP_SECRET;
+
+if (!DATABASE_URL || !OMIE_APP_KEY || !OMIE_APP_SECRET) {
+  console.error('ERRO: DATABASE_URL, OMIE_APP_KEY e OMIE_APP_SECRET são obrigatórios.');
+  process.exit(1);
+}
+
+const pool = new Pool({
+  connectionString: DATABASE_URL,
+  ssl: { rejectUnauthorized: false },
+  max: 5,
+});
+
+// ─── Configurações ────────────────────────────────────────────────────────────
+// Padrão: apenas abril e maio de 2026
+const DATA_INICIO = process.env.DATA_INICIO || '2026-04-01';
+const DATA_FIM    = process.env.DATA_FIM    || (() => {
+  const d = new Date();
+  d.setDate(d.getDate() - 1); // ontem
+  return d.toISOString().slice(0, 10);
+})();
+
+// Omie rate limit: 240 req/min por método, ListarPosEstoque = 1 req por vez
+// → processamento estritamente sequencial (sem delay artificial — cada req leva ~700ms)
+const DELAY_ERRO_MS   = 35000; // 35s após erro de concorrência ou cache
+const MAX_RETRIES     = 3;
+
+const FETCH_TIMEOUT_S = 25;
+
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+function isoToBR(iso) {
+  const [y, m, d] = iso.split('-');
+  return `${d}/${m}/${y}`;
+}
+
+function gerarDatas(inicio, fim) {
+  const datas = [];
+  const cur = new Date(inicio + 'T00:00:00Z');
+  const end = new Date(fim   + 'T00:00:00Z');
+  while (cur <= end) {
+    datas.push(cur.toISOString().slice(0, 10));
+    cur.setUTCDate(cur.getUTCDate() + 1);
+  }
+  return datas;
+}
+
+// ─── Curl assíncrono (não bloqueia event loop) ────────────────────────────────
+function omieFetchAsync(payload) {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify(payload);
+    const args = [
+      '-s', '--max-time', String(FETCH_TIMEOUT_S),
+      '-X', 'POST',
+      'https://app.omie.com.br/api/v1/estoque/consulta/',
+      '-H', 'Content-Type: application/json',
+      '-d', body,
+    ];
+    const child = spawn('curl', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let out = '';
+    let err = '';
+    child.stdout.on('data', d => { out += d; });
+    child.stderr.on('data', d => { err += d; });
+    child.on('close', code => {
+      if (code !== 0) return reject(new Error(`curl exit ${code}: ${err.slice(0, 100)}`));
+      try { resolve(JSON.parse(out)); }
+      catch (e) { reject(new Error(`JSON inválido: ${out.slice(0, 200)}`)); }
+    });
+    child.on('error', e => reject(new Error(`spawn error: ${e.message}`)));
+  });
+}
+
+async function omieFetch(payload) {
+  return omieFetchAsync(payload);
+}
+
+async function omieListarPosEstoque(localCodigo, dataISO) {
+  const dataBR = isoToBR(dataISO);
+  const basePayload = {
+    call: 'ListarPosEstoque',
+    app_key: OMIE_APP_KEY,
+    app_secret: OMIE_APP_SECRET,
+    param: [{
+      nPagina        : 1,
+      nRegPorPagina  : 100,
+      dDataPosicao   : dataBR,
+      cExibeTodos    : 'N',
+      codigo_local_estoque: Number(localCodigo),
+    }],
+  };
+
+  for (let tentativa = 1; tentativa <= MAX_RETRIES; tentativa++) {
+    let r0;
+    try {
+      r0 = await omieFetch(basePayload);
+    } catch (e) {
+      throw new Error(`Curl error: ${e.message}`);
+    }
+
+    // Verifica erro Omie
+    if (r0.faultstring || r0.faultCode) {
+      const msg = String(r0.faultstring || r0.faultCode || '');
+      if (msg.includes('Consumo redundante') || msg.includes('Client-8020') || msg.includes('requisição desse método')) {
+        if (tentativa < MAX_RETRIES) {
+          await sleep(2000 * tentativa);
+          continue;
+        }
+      }
+      if (msg.includes('Nenhum') || msg.includes('nenhum') || msg.includes('0019') || msg.includes('registros para a página')) {
+        return [];
+      }
+      throw new Error(`Omie: ${msg}`);
+    }
+
+    const paginas = Number(r0.nTotPaginas || 1);
+    const itens   = Array.isArray(r0.produtos) ? [...r0.produtos] : [];
+
+    // Busca páginas adicionais sequencialmente (Omie não permite concorrência)
+    for (let pg = 2; pg <= paginas; pg++) {
+      const payloadPg = { ...basePayload, param: [{ ...basePayload.param[0], nPagina: pg }] };
+      const rPg = await omieFetch(payloadPg);
+      if (rPg.faultstring || rPg.faultCode) break; // stop on error
+      if (Array.isArray(rPg.produtos)) itens.push(...rPg.produtos);
+    }
+
+    return itens.filter(it => Number(it?.codigo_local_estoque) === Number(localCodigo));
+  }
+  throw new Error(`Máximo de tentativas atingido para local=${localCodigo} data=${dataISO}`);
+}
+
+async function gravarItens(localCodigo, dataISO, itens) {
+  const clamp = n => Math.max(0, Number(n) || 0);
+  const sql = `
+    INSERT INTO public.omie_estoque_posicao (
+      data_posicao, ingested_at, local_codigo,
+      omie_prod_id, cod_int, codigo, descricao,
+      preco_unitario, saldo, cmc, pendente, estoque_minimo, reservado, fisico
+    ) VALUES (
+      $1::date, now(), $2,
+      $3, $4, $5, $6,
+      $7, $8, $9, $10, $11, $12, $13
+    )
+    ON CONFLICT ON CONSTRAINT uq_posicao_uni
+    DO UPDATE SET
+      descricao      = EXCLUDED.descricao,
+      preco_unitario = EXCLUDED.preco_unitario,
+      saldo          = EXCLUDED.saldo,
+      cmc            = EXCLUDED.cmc,
+      pendente       = EXCLUDED.pendente,
+      estoque_minimo = EXCLUDED.estoque_minimo,
+      reservado      = EXCLUDED.reservado,
+      fisico         = EXCLUDED.fisico,
+      ingested_at    = now()
+  `;
+  const cli = await pool.connect();
+  try {
+    await cli.query('BEGIN');
+    for (const p of itens) {
+      await cli.query(sql, [
+        dataISO, localCodigo,
+        Number(p.nCodProd) || 0,
+        p.cCodInt   || null,
+        p.cCodigo   || '',
+        p.cDescricao || '',
+        clamp(p.nPrecoUnitario),
+        clamp(p.nSaldo),
+        clamp(p.nCMC),
+        clamp(p.nPendente),
+        clamp(p.estoque_minimo),
+        clamp(p.reservado),
+        clamp(p.fisico),
+      ]);
+    }
+    await cli.query('COMMIT');
+  } catch (e) {
+    await cli.query('ROLLBACK');
+    throw e;
+  } finally {
+    cli.release();
+  }
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+(async () => {
+  console.log('='.repeat(70));
+  console.log(' Backfill omie_estoque_posicao 2026');
+  console.log(`  Período : ${DATA_INICIO} → ${DATA_FIM}`);
+  console.log('='.repeat(70));
+
+  // 1) Locais ativos
+  const { rows: locaisRows } = await pool.query(
+    'SELECT local_codigo FROM public.omie_locais_estoque WHERE ativo = TRUE ORDER BY local_codigo'
+  );
+  if (!locaisRows.length) {
+    console.error('Nenhum local ativo encontrado em omie_locais_estoque. Abortando.');
+    process.exit(1);
+  }
+  const locais = locaisRows.map(r => String(r.local_codigo));
+  console.log(`Locais ativos (${locais.length}): ${locais.join(', ')}`);
+
+  // 2) Datas a processar
+  const todasDatas = gerarDatas(DATA_INICIO, DATA_FIM);
+  console.log(`Total de datas: ${todasDatas.length}`);
+
+  // 3) Pares já existentes no banco (para skip)
+  const { rows: existentes } = await pool.query(`
+    SELECT DISTINCT local_codigo, data_posicao::text AS data_posicao
+    FROM public.omie_estoque_posicao
+    WHERE data_posicao BETWEEN $1 AND $2
+  `, [DATA_INICIO, DATA_FIM]);
+  const jaExistem = new Set(existentes.map(r => `${r.data_posicao}|${r.local_codigo}`));
+  console.log(`Pares já existentes no banco: ${jaExistem.size}`);
+
+  // 4) Construir fila de trabalho (skipa existentes)
+  const fila = [];
+  for (const data of todasDatas) {
+    for (const local of locais) {
+      const key = `${data}|${local}`;
+      if (!jaExistem.has(key)) fila.push({ data, local });
+    }
+  }
+
+  const total = locais.length * todasDatas.length;
+  console.log(`Pares a processar: ${fila.length} de ${total} (${total - fila.length} já existiam)\n`);
+
+  if (!fila.length) {
+    console.log('Nada a fazer — todos os pares já existem. Encerrando.');
+    await pool.end();
+    return;
+  }
+
+  // Estimativa (sequencial, ~700ms/req, ~1.5 pages em média)
+  const estimSeg = Math.round(fila.length * 1.5 * 0.7);
+  console.log(`Estimativa: ~${Math.ceil(estimSeg / 60)} min`);
+  console.log('─'.repeat(70));
+
+  let ok = 0, skip = 0, erros = 0;
+
+  for (let i = 0; i < fila.length; i++) {
+    const { data, local } = fila[i];
+    const pct = (((i + 1) / fila.length) * 100).toFixed(1);
+    try {
+      const itens = await omieListarPosEstoque(local, data);
+      if (itens.length === 0) {
+        console.log(`[${i + 1}/${fila.length}] ${pct}% | ${data} | local=${local} → sem saldo`);
+        skip++;
+      } else {
+        await gravarItens(local, data, itens);
+        console.log(`[${i + 1}/${fila.length}] ${pct}% | ${data} | local=${local} → ✓ ${itens.length} itens`);
+        ok++;
+      }
+    } catch (err) {
+      console.log(`[${i + 1}/${fila.length}] ${pct}% | ${data} | local=${local} → ✗ ${err.message}`);
+      erros++;
+    }
+  }
+
+  console.log('\n' + '='.repeat(70));
+  console.log(` CONCLUÍDO: ${ok} gravados | ${skip} sem saldo | ${erros} erros`);
+  console.log('='.repeat(70));
+
+  await pool.end();
+})().catch(err => {
+  console.error('Erro fatal:', err);
+  pool.end().finally(() => process.exit(1));
+});

--- a/server.js
+++ b/server.js
@@ -33644,6 +33644,9 @@ app.listen(PORT, HOST, () => {
   // Notificação diária WhatsApp (08:00)
   const { iniciarCronNotificacaoDiaria } = require('./cron/notificacao_diaria_whatsapp');
   iniciarCronNotificacaoDiaria();
+  // Snapshot diário de estoque (20:00 Brasília) — copia logistica.estoque_atual → omie_estoque_posicao
+  const { iniciarCronSnapshotEstoque } = require('./cron/snapshot_estoque_diario');
+  iniciarCronSnapshotEstoque();
 });
 
 // DEBUG: sanity check do webhook (GET simples)


### PR DESCRIPTION
## Resumo
3 commits temáticos:

- `feat(estoque)`: novo cron `snapshot_estoque_diario.js` (executa às 20h Brasília, copia `logistica.estoque_atual → omie_estoque_posicao`) + script `backfill_estoque_posicao_2026.js`; registrado em `server.js`.
- `feat(producao)`: refatora consulta DB do kanban — nova função `fromDb(onlyMontagem)` com JOIN completo de produto e OS; melhoria de performance e clareza.
- `chore(docs)`: adiciona instrução `.github/instructions/novo-item-menu-lateral.instructions.md`.

## Validação local
- `node --check` em todos os JS alterados: OK
- `pm2 restart intranet_api`: online