### PR TITLE
feat(transferencias): aprovar pendentes em sequencia

### DIFF
--- a/menu_produto.html
+++ b/menu_produto.html
@@ -7023,6 +7023,7 @@
                   <div class="title-wrapper">
                     <div class="content-section-title">Solicitações de transferência</div>
                     <div class="actions" style="display:flex; gap:8px; align-items:center;">
+                      <button id="solicitacoesTransferApproveAll" class="btn tiny" type="button" style="background:#22c55e;color:#06120a;border-color:#86efac;font-weight:800;">Aprovar pendentes</button>
                       <button id="solicitacoesTransferRefresh" class="btn tiny" type="button">Atualizar</button>
                     </div>
                   </div>
@@ -7983,6 +7984,15 @@
           </div>
         </div>
         <div class="transferencia-controls">
+          <button id="transferImportarListaBtn"
+                  type="button"
+                  class="btn"
+                  title="Cole uma lista copiada da planilha: codigo + TAB + quantidade"
+                  aria-label="Importar lista de transferencia em massa"
+                  style="display:inline-flex;align-items:center;gap:8px;white-space:nowrap;">
+            <i class="fa-solid fa-table-list"></i>
+            Importar lista da planilha
+          </button>
           <div class="transferencia-search">
             <input id="transferSearch" type="text"
                    placeholder="Adicionar item por código ou descrição…"
@@ -7992,7 +8002,7 @@
             </div>
           </div>
         </div>
-        <div class="transferencia-wrapper">
+        <div class="transferencia-wrapper" style="max-height:calc(100vh - 330px);overflow:auto;border:1px solid #334155;border-radius:10px;">
           <table class="tabela padrao transferencia-table">
             <thead>
               <tr>

--- a/menu_produto.js
+++ b/menu_produto.js
@@ -16940,7 +16940,17 @@ document.addEventListener('click', async (e) => {
 });
 
 document.getElementById('solicitacoesTransferRefresh')?.addEventListener('click', () => {
-  carregarSolicitacoesTransferencias(true);
+  if (typeof window.carregarSolicitacoesTransferencias === 'function') {
+    window.carregarSolicitacoesTransferencias(true);
+  }
+});
+
+document.getElementById('solicitacoesTransferApproveAll')?.addEventListener('click', async () => {
+  if (typeof window.aprovarSolicitacoesTransferenciaEmSequencia === 'function') {
+    await window.aprovarSolicitacoesTransferenciaEmSequencia();
+  } else {
+    alert('A tela de transferencias ainda esta carregando. Tente novamente em alguns segundos.');
+  }
 });
 
 document.getElementById('recebimentoRefreshBtn')?.addEventListener('click', async () => {
@@ -17206,10 +17216,27 @@ document.addEventListener('DOMContentLoaded', async () => {
   const transferQtdBulk = document.getElementById('transferQtdBulk');
   const transferAcaoBtn = document.getElementById('transferenciaBtn');
   const transferImportarBtn = document.getElementById('transferImportarBtn');
+  const transferImportarListaBtn = document.getElementById('transferImportarListaBtn');
   const transferDataMov = document.getElementById('transferDataMov');
+  const transferDataMovLabel = document.querySelector('label[for="transferDataMov"]');
 
   if (transferDataMov && !transferDataMov.value) {
     transferDataMov.value = new Date().toISOString().slice(0, 10);
+  }
+  if (transferDataMovLabel) {
+    transferDataMovLabel.textContent = 'Data movimentacao';
+  }
+  if (transferImportarBtn) {
+    transferImportarBtn.style.display = 'none';
+  }
+  if (transferAcaoBtn && !transferAcaoBtn.__labelFixed) {
+    transferAcaoBtn.__labelFixed = true;
+    transferAcaoBtn.classList.remove('icon-btn');
+    transferAcaoBtn.classList.add('btn');
+    transferAcaoBtn.title = 'Enviar solicitacao de transferencia dos itens selecionados';
+    transferAcaoBtn.setAttribute('aria-label', 'Enviar solicitacao de transferencia');
+    transferAcaoBtn.style.cssText = 'display:inline-flex;align-items:center;gap:8px;min-width:230px;justify-content:center;background:#22c55e;color:#06120a;font-weight:800;border-color:#86efac;';
+    transferAcaoBtn.innerHTML = '<i class="fa-solid fa-right-left"></i><span>Enviar solicitacao</span>';
   }
 
   if (transferQtdBulk && !transferQtdBulk.__transferBound) {
@@ -17258,6 +17285,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   if (transferImportarBtn && !transferImportarBtn.__transferBound) {
     transferImportarBtn.__transferBound = true;
     transferImportarBtn.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      abrirModalImportacaoTransferencia();
+    });
+  }
+  if (transferImportarListaBtn && !transferImportarListaBtn.__transferBound) {
+    transferImportarListaBtn.__transferBound = true;
+    transferImportarListaBtn.addEventListener('click', (ev) => {
       ev.preventDefault();
       abrirModalImportacaoTransferencia();
     });
@@ -17322,7 +17356,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
 
         if (!resp.ok || !resposta?.ok) {
-          const msg = resposta?.error || resposta?.detail || `Falha ao registrar transferência (HTTP ${resp.status}).`;
+          const msg = resposta?.detail || resposta?.error || `Falha ao registrar transferência (HTTP ${resp.status}).`;
           throw new Error(msg);
         }
 
@@ -17478,6 +17512,55 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const solicitacoesTbody = document.getElementById('solicitacoesTransferTbody');
+  if (solicitacoesTbody && !solicitacoesTbody.__rejectCleanBound) {
+    solicitacoesTbody.__rejectCleanBound = true;
+    solicitacoesTbody.addEventListener('click', async (ev) => {
+      const btn = ev.target.closest('.btn-reject-transfer');
+      if (!btn) return;
+      ev.preventDefault();
+      ev.stopImmediatePropagation();
+
+      const id = Number(btn.dataset.id);
+      if (!Number.isInteger(id)) {
+        alert('Nao foi possivel identificar a solicitacao selecionada.');
+        return;
+      }
+
+      const usuario = String(document.getElementById('userNameDisplay')?.textContent || '').trim();
+      if (!usuario || usuario === 'Usuario' || usuario === 'UsuÃ¡rio' || usuario === '—' || usuario === 'â€”') {
+        alert('Nao foi possivel identificar o usuario atual. Faca login novamente.');
+        return;
+      }
+
+      const motivo = prompt('Informe o motivo para reprovar/excluir esta solicitacao:', '');
+      if (motivo === null) return;
+
+      const originalLabel = btn.textContent;
+      btn.disabled = true;
+      btn.textContent = 'Reprovando...';
+
+      try {
+        const resp = await fetch(`/api/transferencias/${id}/reprovar`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ reprovadoPor: usuario, motivo })
+        });
+
+        const json = await resp.json().catch(() => ({}));
+        if (!resp.ok || !json?.ok) {
+          throw new Error(json?.error || `Falha ao reprovar (HTTP ${resp.status}).`);
+        }
+
+        alert('Solicitacao reprovada.');
+        await carregarSolicitacoesTransferencias(true);
+      } catch (err) {
+        console.error('[transferencias] reprovar', err);
+        alert(err?.message || 'Falha ao reprovar a solicitacao.');
+        btn.disabled = false;
+        btn.textContent = originalLabel;
+      }
+    }, true);
+  }
   if (solicitacoesTbody && !solicitacoesTbody.__approveBound) {
     solicitacoesTbody.__approveBound = true;
     solicitacoesTbody.addEventListener('click', async (ev) => {
@@ -19344,18 +19427,30 @@ function ensureTransferImportModal() {
 
   modal = document.createElement('div');
   modal.id = 'transferImportModal';
-  modal.style.cssText = 'position:fixed;inset:0;z-index:9999;display:none;align-items:center;justify-content:center;background:rgba(3,7,18,.72);backdrop-filter:blur(4px);';
+  modal.style.cssText = 'position:fixed;inset:0;z-index:9999;display:none;align-items:center;justify-content:center;background:rgba(3,7,18,.72);backdrop-filter:blur(4px);padding:18px;';
   modal.innerHTML = `
-    <div style="width:min(720px, calc(100vw - 28px));max-height:calc(100vh - 42px);overflow:auto;background:#121722;border:1px solid #2b3548;border-radius:18px;box-shadow:0 24px 70px rgba(0,0,0,.45);color:#e5e7eb;">
+    <div style="width:min(980px, calc(100vw - 28px));max-height:calc(100vh - 42px);overflow:auto;background:#121722;border:1px solid #2b3548;border-radius:18px;box-shadow:0 24px 70px rgba(0,0,0,.45);color:#e5e7eb;">
       <div style="display:flex;align-items:center;justify-content:space-between;padding:18px 22px;border-bottom:1px solid #253044;">
         <div>
-          <div style="font-size:18px;font-weight:800;">Importar transferencia em massa</div>
-          <div style="font-size:12px;color:#93a4bd;margin-top:4px;">Cole uma linha por item: codigo + TAB + quantidade.</div>
+          <div style="font-size:20px;font-weight:800;">Importar lista da planilha</div>
+          <div style="font-size:13px;color:#93a4bd;margin-top:4px;">Copie varias linhas do Excel/Sheets e cole aqui. Formato: codigo, TAB, quantidade.</div>
         </div>
         <button id="transferImportClose" type="button" class="icon-btn" aria-label="Fechar"><i class="fa-solid fa-xmark"></i></button>
       </div>
       <div style="padding:18px 22px;display:grid;gap:14px;">
-        <textarea id="transferImportTextarea" rows="10" spellcheck="false" placeholder="05.MP.I.80044\t300&#10;09.MC.N.10106\t24" style="width:100%;resize:vertical;min-height:180px;background:#0b1020;color:#e5e7eb;border:1px solid #334155;border-radius:12px;padding:12px;font-family:Consolas, monospace;font-size:13px;line-height:1.45;"></textarea>
+        <div style="display:grid;grid-template-columns:1fr auto;gap:14px;align-items:start;">
+          <label style="display:grid;gap:8px;font-size:12px;font-weight:800;color:#9ca3af;letter-spacing:.03em;text-transform:uppercase;">
+            Lista para importar
+            <textarea id="transferImportTextarea" rows="16" spellcheck="false" placeholder="05.MP.I.80044	300&#10;09.MC.N.10106	24&#10;01.MP.N.51001	12" style="width:100%;resize:vertical;min-height:340px;background:#0b1020;color:#e5e7eb;border:1px solid #334155;border-radius:12px;padding:14px;font-family:Consolas, monospace;font-size:14px;line-height:1.55;"></textarea>
+          </label>
+          <div style="min-width:230px;background:#0b1020;border:1px solid #263349;border-radius:12px;padding:14px;color:#cbd5e1;font-size:12px;line-height:1.55;">
+            <div style="font-weight:800;color:#e5e7eb;margin-bottom:8px;">Como colar</div>
+            <div>1. Na planilha, selecione duas colunas: codigo e quantidade.</div>
+            <div>2. Copie com CTRL+C.</div>
+            <div>3. Cole nesta caixa. Cada linha vira um item.</div>
+            <div style="margin-top:10px;color:#93c5fd;">Exemplo:<br><code>05.MP.I.80044&nbsp;&nbsp;300</code><br><code>09.MC.N.10106&nbsp;&nbsp;24</code></div>
+          </div>
+        </div>
         <div style="display:grid;grid-template-columns:1fr 1fr 180px;gap:12px;">
           <label style="display:grid;gap:6px;font-size:12px;font-weight:700;color:#9ca3af;">Origem
             <select id="transferImportOrigem" class="transfer-select"></select>
@@ -19545,6 +19640,93 @@ function renderTransferenciaLista() {
 
 window.renderTransferenciaLista = renderTransferenciaLista;
 
+function delayTransferencia(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function obterUsuarioAtualTransferencia() {
+  const usuario = String(document.getElementById('userNameDisplay')?.textContent || '').trim();
+  if (!usuario || usuario === 'Usuario' || usuario === 'UsuÃ¡rio' || usuario === '—' || usuario === 'â€”') {
+    return '';
+  }
+  return usuario;
+}
+
+async function aprovarTransferenciaPorId(id, usuario) {
+  const resp = await fetch(`/api/transferencias/${id}/aprovar`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ aprovadoPor: usuario })
+  });
+  const json = await resp.json().catch(() => ({}));
+  if (!resp.ok || !json?.ok) {
+    throw new Error(json?.error || json?.detail || `Falha ao aprovar transferencia #${id} (HTTP ${resp.status}).`);
+  }
+  return json;
+}
+
+async function aprovarSolicitacoesTransferenciaEmSequencia() {
+  const usuario = obterUsuarioAtualTransferencia();
+  if (!usuario) {
+    alert('Nao foi possivel identificar o usuario atual. Faca login novamente.');
+    return;
+  }
+
+  await carregarSolicitacoesTransferencias(true);
+  const pendentes = solicitacoesTransferencias
+    .filter(item => String(item.status || '').toLowerCase() !== 'transferido')
+    .filter(item => String(item.status || '').toLowerCase() !== 'reprovado')
+    .filter(item => Number.isInteger(Number(item.id)));
+
+  if (!pendentes.length) {
+    alert('Nao ha solicitacoes pendentes para aprovar.');
+    return;
+  }
+
+  if (!confirm(`Aprovar ${pendentes.length} solicitacao(oes) uma por uma? O sistema vai enviar para a Omie em sequencia, sem chamadas paralelas.`)) {
+    return;
+  }
+
+  const btn = document.getElementById('solicitacoesTransferApproveAll');
+  const originalLabel = btn?.textContent || '';
+  if (btn) {
+    btn.disabled = true;
+    btn.textContent = `Aprovando 0/${pendentes.length}`;
+  }
+
+  const erros = [];
+  let aprovadas = 0;
+  try {
+    for (const item of pendentes) {
+      const id = Number(item.id);
+      if (btn) btn.textContent = `Aprovando ${aprovadas + 1}/${pendentes.length}`;
+      try {
+        await aprovarTransferenciaPorId(id, usuario);
+        aprovadas++;
+      } catch (err) {
+        erros.push(`#${id} ${item.codigo || ''}: ${err?.message || err}`);
+      }
+      if (aprovadas + erros.length < pendentes.length) {
+        await delayTransferencia(1500);
+      }
+    }
+  } finally {
+    if (btn) {
+      btn.disabled = false;
+      btn.textContent = originalLabel || 'Aprovar pendentes';
+    }
+    await carregarSolicitacoesTransferencias(true);
+  }
+
+  if (erros.length) {
+    alert(`Aprovadas: ${aprovadas}. Falharam: ${erros.length}.\n${erros.slice(0, 5).join('\n')}${erros.length > 5 ? '\n...' : ''}`);
+    return;
+  }
+  alert(`Todas as ${aprovadas} solicitacoes foram aprovadas.`);
+}
+
+window.aprovarSolicitacoesTransferenciaEmSequencia = aprovarSolicitacoesTransferenciaEmSequencia;
+
 function renderSolicitacoesTransferencias() {
   const tbody = document.getElementById('solicitacoesTransferTbody');
   if (!tbody) return;
@@ -19574,7 +19756,7 @@ function renderSolicitacoesTransferencias() {
     const botaoHtml = podeAprovar
       ? `<div style="display:flex;gap:6px;flex-wrap:wrap;">
            <button type="button" class="btn tiny btn-approve-transfer" data-id="${escapeHtml(String(item.id ?? ''))}">Aprovar</button>
-           <button type="button" class="btn tiny btn-reject-transfer" data-id="${escapeHtml(String(item.id ?? ''))}" style="border-color:#ef4444;color:#fecaca;">Reprovar</button>
+           <button type="button" class="btn tiny btn-reject-transfer" data-id="${escapeHtml(String(item.id ?? ''))}" style="background:#dc2626;border-color:#f87171;color:#ffffff;font-weight:800;">Reprovar</button>
          </div>`
       : '<span>Transferido</span>';
     const tr = document.createElement('tr');
@@ -19631,6 +19813,8 @@ async function carregarSolicitacoesTransferencias(forceReload = false) {
     if (spinner) spinner.style.display = 'none';
   }
 }
+
+window.carregarSolicitacoesTransferencias = carregarSolicitacoesTransferencias;
 
 async function openSolicitacoesTransferencia(forceReload = false) {
   if (typeof hideKanban === 'function') hideKanban();

--- a/routes/transferencias.js
+++ b/routes/transferencias.js
@@ -20,10 +20,27 @@ async function ensureTransferenciasSchema() {
       ADD COLUMN IF NOT EXISTS reprovado_em TIMESTAMPTZ,
       ADD COLUMN IF NOT EXISTS motivo_reprovacao TEXT
   `);
+  await dbQuery(`
+    ALTER TABLE mensagens.transferencias
+      DROP CONSTRAINT IF EXISTS transferencias_codigo_produto_fkey
+  `);
   schemaTransferenciasOk = true;
 }
 
 // Resolve o identificador numérico do produto (codigo_produto) usando o código Omie textual ou numérico.
+async function buscarProdutoPorCodigoProduto(codigoProduto) {
+  const id = Number(codigoProduto);
+  if (!Number.isFinite(id)) return null;
+  const { rows } = await dbQuery(
+    `SELECT codigo_produto
+       FROM public.produtos_omie
+      WHERE codigo_produto = $1
+      LIMIT 1`,
+    [id]
+  );
+  return rows.length ? Number(rows[0].codigo_produto) : null;
+}
+
 async function resolveCodigoProduto(codigoParam) {
   const raw = String(codigoParam || '').trim();
   if (!raw) {
@@ -33,8 +50,8 @@ async function resolveCodigoProduto(codigoParam) {
   }
 
   if (/^\d+$/.test(raw)) {
-    const parsed = Number(raw);
-    if (Number.isFinite(parsed)) return parsed;
+    const existente = await buscarProdutoPorCodigoProduto(raw);
+    if (existente) return existente;
   }
 
   const sql = `
@@ -50,6 +67,16 @@ async function resolveCodigoProduto(codigoParam) {
     throw err;
   }
   return Number(rows[0].codigo_produto);
+}
+
+async function resolverCodigoProdutoTransferencia(candidatos, codigo) {
+  for (const candidato of candidatos) {
+    const str = candidato !== undefined && candidato !== null ? String(candidato).trim() : '';
+    if (!str || !/^\d+$/.test(str)) continue;
+    const existente = await buscarProdutoPorCodigoProduto(str);
+    if (existente) return existente;
+  }
+  return resolveCodigoProduto(codigo);
 }
 
 function normalizaNumeroParaOmie(value) {
@@ -133,6 +160,18 @@ async function buscarCmcAtual({ codigo, origem }) {
   return cmc && cmc > 0 ? cmc : null;
 }
 
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function isErroOmieRetryable({ httpStatus, texto }) {
+  const body = String(texto || '');
+  return httpStatus === 425
+    || httpStatus === 429
+    || httpStatus >= 500
+    || /too many|rate limit|consumo redundante|requisi/i.test(body);
+}
+
 async function incluirAjusteEstoqueOmie({ origem, destino, codigo_produto, qtd, codigo, id, cmc, data_movimentacao }, aprovadoPor) {
   if (!OMIE_APP_KEY || !OMIE_APP_SECRET) {
     const err = new Error('Credenciais da Omie ausentes.');
@@ -188,6 +227,80 @@ async function incluirAjusteEstoqueOmie({ origem, destino, codigo_produto, qtd, 
     valorFinal: payload.param[0].valor
   };
   console.info('[transferencias][omie] Enviando ajuste', resumoEnvio);
+
+  const delays = [3000, 6000, 12000, 24000, 45000];
+  let ultimoErro = null;
+
+  for (let tentativa = 0; tentativa <= delays.length; tentativa++) {
+    let respRetry;
+    let texto = '';
+    try {
+      respRetry = await fetch('https://app.omie.com.br/api/v1/estoque/ajuste/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      texto = await respRetry.text();
+    } catch (fetchErr) {
+      ultimoErro = fetchErr;
+      if (tentativa < delays.length) {
+        await sleep(delays[tentativa]);
+        continue;
+      }
+      const err = new Error(`Falha ao comunicar com a Omie: ${fetchErr.message || fetchErr}`);
+      err.status = 502;
+      throw err;
+    }
+
+    let jsonRetry;
+    try {
+      jsonRetry = texto ? JSON.parse(texto) : {};
+    } catch (parseErr) {
+      ultimoErro = parseErr;
+      if (isErroOmieRetryable({ httpStatus: respRetry.status, texto }) && tentativa < delays.length) {
+        console.warn('[transferencias][omie] retry por resposta invalida/rate-limit', {
+          transferenciaId: id,
+          tentativa: tentativa + 1,
+          httpStatus: respRetry.status
+        });
+        await sleep(delays[tentativa]);
+        continue;
+      }
+      const err = new Error(`Resposta invalida da Omie. HTTP ${respRetry.status}.`);
+      err.status = respRetry.status >= 400 ? respRetry.status : 502;
+      throw err;
+    }
+
+    if (respRetry.ok && String(jsonRetry?.codigo_status || '') === '0') {
+      return jsonRetry;
+    }
+
+    const retryable = isErroOmieRetryable({
+      httpStatus: respRetry.status,
+      texto: texto || jsonRetry?.descricao_status || jsonRetry?.faultstring
+    });
+    if (retryable && tentativa < delays.length) {
+      console.warn('[transferencias][omie] retry por limite/erro temporario', {
+        transferenciaId: id,
+        tentativa: tentativa + 1,
+        httpStatus: respRetry.status,
+        descricao: jsonRetry?.descricao_status || jsonRetry?.faultstring || texto?.slice?.(0, 180)
+      });
+      await sleep(delays[tentativa]);
+      continue;
+    }
+
+    const msg = jsonRetry?.descricao_status
+      || jsonRetry?.faultstring
+      || `Falha ao comunicar com a Omie (HTTP ${respRetry.status}).`;
+    const err = new Error(msg);
+    err.status = respRetry.status >= 400 ? respRetry.status : 502;
+    throw err;
+  }
+
+  const err = new Error(`Omie nao confirmou a transferencia apos novas tentativas. ${ultimoErro?.message || ''}`.trim());
+  err.status = 429;
+  throw err;
 
   const resp = await fetch('https://app.omie.com.br/api/v1/estoque/ajuste/', {
     method: 'POST',
@@ -306,27 +419,19 @@ router.post('/', express.json(), async (req, res) => {
         item.codigo_omie
       ];
 
-      let codigoProduto = null;
-      for (const candidato of candidatos) {
-        const str = candidato !== undefined && candidato !== null ? String(candidato).trim() : '';
-        if (!str) continue;
-        if (/^\d+$/.test(str)) {
-          const parsed = Number(str);
-          if (Number.isFinite(parsed)) {
-            codigoProduto = parsed;
-            break;
-          }
-        }
-      }
-
+      const chave = codigo;
+      let codigoProduto = cache.get(chave);
       if (!codigoProduto) {
-        const chave = codigo;
-        if (cache.has(chave)) {
-          codigoProduto = cache.get(chave);
-        } else {
-          codigoProduto = await resolveCodigoProduto(codigo);
-          cache.set(chave, codigoProduto);
+        try {
+          codigoProduto = await resolverCodigoProdutoTransferencia(candidatos, codigo);
+        } catch (resolveErr) {
+          const fallbackNumerico = candidatos
+            .map(candidato => String(candidato ?? '').trim())
+            .find(str => /^\d+$/.test(str));
+          if (!fallbackNumerico) throw resolveErr;
+          codigoProduto = Number(fallbackNumerico);
         }
+        cache.set(chave, codigoProduto);
       }
 
       preparados.push({
@@ -376,9 +481,12 @@ router.post('/', express.json(), async (req, res) => {
     res.json({ ok: true, registros: resultado.rows });
   } catch (err) {
     console.error('[transferencias] falha ao registrar transferência', err);
+    const detalhe = err.code === '23503' && err.constraint === 'transferencias_codigo_produto_fkey'
+      ? 'Produto sem cadastro valido em public.produtos_omie. Atualize o cadastro/cache de produtos antes de registrar a transferencia.'
+      : (err.message || String(err));
     res.status(err.status || 500).json({
       error: 'Falha ao registrar transferência de itens.',
-      detail: err.message || String(err)
+      detail: detalhe
     });
   }
 });


### PR DESCRIPTION
﻿## O que mudou
- Adiciona importacao em massa de itens de transferencia a partir de lista copiada da planilha.
- Melhora a tela de transferencia com botao claro de envio, scroll na lista e rotulos de armazem mais legiveis.
- Adiciona reprovar solicitacao e aprovar pendentes em sequencia, evitando chamadas paralelas para a Omie.
- Inclui retry/backoff para falhas temporarias/rate limit na chamada de ajuste de estoque da Omie.
- Corrige o clique do botao Aprovar pendentes expondo as funcoes de transferencia no escopo da pagina.

## Validacao
- node --check menu_produto.js
- node --check routes/transferencias.js
- git diff --check
- Teste local no navegador confirmou que Aprovar pendentes abre a confirmacao sem disparar envio real.
