### PR TITLE
feat(relatorio-at): top10 por tabela, botao imprimir no topo e top modelos

### DIFF
--- a/menu_produto.js
+++ b/menu_produto.js
@@ -15008,7 +15008,7 @@ document.querySelectorAll('#atTabelaWrapper thead th[data-col]').forEach(th => {
         }
         const totaisPorTag = {};
         rows.forEach(r => { totaisPorTag[r.tag] = (totaisPorTag[r.tag] || 0) + r.total; });
-        const tags = Object.keys(totaisPorTag).sort((a, b) => totaisPorTag[b] - totaisPorTag[a]);
+        const tags = Object.keys(totaisPorTag).sort((a, b) => totaisPorTag[b] - totaisPorTag[a]).slice(0, 10);
 
         const thMeses = meses.map(m =>
           `<th class="th-mes" style="background:${cor};">${m.label}</th>`
@@ -15211,7 +15211,13 @@ document.querySelectorAll('#atTabelaWrapper thead th[data-col]').forEach(th => {
     <h1>Relatório — Gráfico AT</h1>
     <div class="sub">Gerado em ${new Date().toLocaleString('pt-BR')}</div>
   </div>
-  <div class="badge">Período: ${periodo}</div>
+  <div style="display:flex;align-items:center;gap:12px;">
+    <button onclick="window.print()" class="no-print"
+      style="padding:9px 22px;background:#1e3a5f;color:#fff;border:none;border-radius:7px;cursor:pointer;font-size:13px;font-weight:600;">
+      &#128438; Imprimir / Salvar PDF
+    </button>
+    <div class="badge">Período: ${periodo}</div>
+  </div>
 </div>
 
 <div class="graficos-row">
@@ -15228,13 +15234,7 @@ document.querySelectorAll('#atTabelaWrapper thead th[data-col]').forEach(th => {
 ${pivotHtml('OS aberta', '#1d6a2f', data.qualidade)}
 ${pivotHtml('Atendimento Rápido', '#7c2d12', data.rapido)}
 ${pivotHtml('Menções (Pós abertura de OS)', '#4c1d95', data.mencoes)}
-
-<div class="no-print" style="margin-top:24px;padding-top:16px;border-top:1px solid #e5e7eb;">
-  <button onclick="window.print()"
-    style="padding:9px 22px;background:#1e3a5f;color:#fff;border:none;border-radius:7px;cursor:pointer;font-size:13px;font-weight:600;">
-    &#128438; Imprimir / Salvar PDF
-  </button>
-</div>
+${pivotHtml('Top 10 Modelos', '#0c4a6e', data.modelos)}
 
 </body>
 </html>`;

--- a/routes/sacEnvios.js
+++ b/routes/sacEnvios.js
@@ -5767,7 +5767,7 @@ router.get('/at/graficos/por-mes', async (req, res) => {
 // GET /at/graficos/relatorio — dados para relatório PDF (últimos 3 meses), breakdown por tag × mês
 router.get('/at/graficos/relatorio', async (req, res) => {
   try {
-    const [rQ, rR, rM] = await Promise.all([
+    const [rQ, rR, rM, rMod] = await Promise.all([
       // OS aberta (Qualidade) — por tag × mês
       pool.query(`
         SELECT
@@ -5808,6 +5808,18 @@ router.get('/at/graficos/relatorio', async (req, res) => {
         GROUP BY 1, 2
         ORDER BY tag, mes
       `),
+      // Top Modelos — todos os tipos, por modelo × mês
+      pool.query(`
+        SELECT
+          COALESCE(NULLIF(TRIM(modelo),''), '(sem modelo)') AS tag,
+          TO_CHAR(DATE_TRUNC('month', data), 'YYYY-MM')     AS mes,
+          COUNT(*)::int                                      AS total
+        FROM sac.at
+        WHERE data >= DATE_TRUNC('month', CURRENT_DATE) - INTERVAL '3 months'
+          AND data <  DATE_TRUNC('month', CURRENT_DATE)
+        GROUP BY 1, 2
+        ORDER BY tag, mes
+      `),
     ]);
 
     // Meses do eixo X (YYYY-MM e label legível)
@@ -5828,6 +5840,7 @@ router.get('/at/graficos/relatorio', async (req, res) => {
       qualidade: rQ.rows,
       rapido:    rR.rows,
       mencoes:   rM.rows,
+      modelos:   rMod.rows,
     });
   } catch (err) {
     console.error('[SAC/AT] erro relatorio:', err);


### PR DESCRIPTION
## Resumo\n- **Top 10**: OS aberta, Atendimento Rápido e Menções agora exibem apenas os 10 maiores por Total\n- **Botão Imprimir/Salvar PDF** movido para o cabeçalho (canto superior direito), ao lado do badge de período\n- **Nova tabela Top 10 Modelos** — agrupa todos os atendimentos por modelo do produto no mesmo período\n- Backend: novo campo `modelos` no payload de `/api/sac/at/graficos/relatorio`