### PR TITLE
feat(graf-at): filtro tipo, reordenar gráficos e gráfico proporção OS/vendas

### DIFF
--- a/menu_produto.html
+++ b/menu_produto.html
@@ -4505,12 +4505,19 @@
                   <i class="fa-solid fa-chart-line" style="color:#818cf8;"></i>
                   Gráfico AT
                 </div>
-                <div style="display:flex;gap:8px;align-items:center;margin-left:auto;">
+                <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-left:auto;">
+                  <!-- Filtro Período -->
                   <div style="display:flex;gap:6px;">
                     <button class="at-graf-periodo-btn-pg" data-per="3" style="padding:5px 12px;border-radius:8px;border:1px solid #4f46e5;background:rgba(79,70,229,.25);color:#a5b4fc;font-size:12px;cursor:pointer;">3 meses</button>
                     <button class="at-graf-periodo-btn-pg" data-per="6" style="padding:5px 12px;border-radius:8px;border:1px solid #374151;background:rgba(255,255,255,.04);color:#9ca3af;font-size:12px;cursor:pointer;">6 meses</button>
                     <button class="at-graf-periodo-btn-pg" data-per="12" style="padding:5px 12px;border-radius:8px;border:1px solid #374151;background:rgba(255,255,255,.04);color:#9ca3af;font-size:12px;cursor:pointer;">12 meses</button>
                     <button class="at-graf-periodo-btn-pg" data-per="0" style="padding:5px 12px;border-radius:8px;border:1px solid #374151;background:rgba(255,255,255,.04);color:#9ca3af;font-size:12px;cursor:pointer;">Tudo</button>
+                  </div>
+                  <!-- Filtro Tipo -->
+                  <div style="display:flex;gap:6px;border-left:1px solid #1e293b;padding-left:8px;">
+                    <button class="at-graf-tipo-btn-pg" data-tipo="Qualidade" style="padding:5px 12px;border-radius:8px;border:1px solid #10b981;background:rgba(16,185,129,.22);color:#6ee7b7;font-size:12px;cursor:pointer;">Qualidade</button>
+                    <button class="at-graf-tipo-btn-pg" data-tipo="Atendimento Rápido" style="padding:5px 12px;border-radius:8px;border:1px solid #374151;background:rgba(255,255,255,.04);color:#9ca3af;font-size:12px;cursor:pointer;">Atend. Rápido</button>
+                    <button class="at-graf-tipo-btn-pg" data-tipo="" style="padding:5px 12px;border-radius:8px;border:1px solid #374151;background:rgba(255,255,255,.04);color:#9ca3af;font-size:12px;cursor:pointer;">Todos</button>
                   </div>
                   <button id="atGrafPgRefreshBtn" type="button" title="Atualizar"
                     style="padding:6px 12px;border-radius:8px;border:1px solid #374151;background:rgba(255,255,255,.04);color:#9ca3af;cursor:pointer;display:flex;align-items:center;gap:6px;font-size:13px;">
@@ -4523,19 +4530,19 @@
                 </div>
               </div>
 
-              <!-- Gráfico 1 -->
+              <!-- Gráfico 1 — Top Modelos -->
               <div style="background:rgba(255,255,255,.03);border:1px solid #1e293b;border-radius:12px;padding:16px;margin-top:16px;">
-                <div style="font-size:13px;font-weight:700;color:#a5b4fc;margin-bottom:12px;display:flex;align-items:center;gap:6px;">
-                  <i class="fa-solid fa-map-location-dot"></i>
-                  Gráfico 1 — Atendimentos por Estado / Mês (Qualidade)
+                <div style="font-size:13px;font-weight:700;color:#f59e0b;margin-bottom:12px;display:flex;align-items:center;gap:6px;">
+                  <i class="fa-solid fa-award"></i>
+                  Gráfico 1 — Top Modelos por Mês
                 </div>
-                <div id="atGrafPg1Status" style="font-size:12px;color:var(--inactive-color);margin-bottom:8px;display:none;">Carregando...</div>
-                <div style="position:relative;height:340px;">
-                  <canvas id="atGrafPg1Canvas"></canvas>
+                <div id="atGrafPg0Status" style="font-size:12px;color:var(--inactive-color);margin-bottom:8px;display:none;">Carregando...</div>
+                <div style="position:relative;height:300px;">
+                  <canvas id="atGrafPg0Canvas"></canvas>
                 </div>
               </div>
 
-              <!-- Gráfico 2 -->
+              <!-- Gráfico 2 — Picos -->
               <div style="background:rgba(255,255,255,.03);border:1px solid #1e293b;border-radius:12px;padding:16px;margin-top:18px;">
                 <div style="font-size:13px;font-weight:700;color:#34d399;margin-bottom:12px;display:flex;align-items:center;gap:6px;">
                   <i class="fa-solid fa-chart-line"></i>
@@ -4547,15 +4554,28 @@
                 </div>
               </div>
 
-              <!-- Gráfico 3 — Top Modelos -->
+              <!-- Gráfico 3 — Por Estado/Mês -->
               <div style="background:rgba(255,255,255,.03);border:1px solid #1e293b;border-radius:12px;padding:16px;margin-top:18px;">
-                <div style="font-size:13px;font-weight:700;color:#f59e0b;margin-bottom:12px;display:flex;align-items:center;gap:6px;">
-                  <i class="fa-solid fa-award"></i>
-                  Gráfico 3 — Top Modelos por Mês (Qualidade)
+                <div style="font-size:13px;font-weight:700;color:#a5b4fc;margin-bottom:12px;display:flex;align-items:center;gap:6px;">
+                  <i class="fa-solid fa-map-location-dot"></i>
+                  Gráfico 3 — Atendimentos por Estado / Mês
                 </div>
-                <div id="atGrafPg0Status" style="font-size:12px;color:var(--inactive-color);margin-bottom:8px;display:none;">Carregando...</div>
-                <div style="position:relative;height:300px;">
-                  <canvas id="atGrafPg0Canvas"></canvas>
+                <div id="atGrafPg1Status" style="font-size:12px;color:var(--inactive-color);margin-bottom:8px;display:none;">Carregando...</div>
+                <div style="position:relative;height:340px;">
+                  <canvas id="atGrafPg1Canvas"></canvas>
+                </div>
+              </div>
+
+              <!-- Gráfico 4 — Proporção OS/Vendas -->
+              <div style="background:rgba(255,255,255,.03);border:1px solid #1e293b;border-radius:12px;padding:16px;margin-top:18px;">
+                <div style="font-size:13px;font-weight:700;color:#f472b6;margin-bottom:6px;display:flex;align-items:center;gap:6px;">
+                  <i class="fa-solid fa-percent"></i>
+                  Gráfico 4 — Proporção OS / Vendas por Modelo (% de falhas)
+                </div>
+                <div style="font-size:11px;color:#64748b;margin-bottom:10px;">OS abertas ÷ unidades vendidas (etapas 70/80) × 100. Quanto maior, mais falhas relativas ao volume vendido.</div>
+                <div id="atGrafPg4Status" style="font-size:12px;color:var(--inactive-color);margin-bottom:8px;display:none;">Carregando...</div>
+                <div style="position:relative;height:320px;">
+                  <canvas id="atGrafPg4Canvas"></canvas>
                 </div>
               </div>
 

--- a/menu_produto.js
+++ b/menu_produto.js
@@ -14488,8 +14488,10 @@ document.querySelectorAll('#atTabelaWrapper thead th[data-col]').forEach(th => {
   let _pg01Instance = null;
   let _pg1Instance = null;
   let _pg2Instance = null;
+  let _pg4Instance = null;
   let _pgMesesSet  = [];
   let _pgPeriodo   = 3;
+  let _pgTipo      = 'Qualidade';
   let _pgInicializado = false;
 
   // Helpers locais (réplica das funções da IIFE principal)
@@ -14534,7 +14536,7 @@ document.querySelectorAll('#atTabelaWrapper thead th[data-col]').forEach(th => {
     if (status) { status.style.display = 'block'; status.textContent = 'Carregando...'; status.style.color = ''; }
 
     try {
-      const resp = await fetch('/api/sac/at/graficos/por-modelo-mes?tipo=Qualidade', { credentials: 'include' });
+      const resp = await fetch(`/api/sac/at/graficos/por-modelo-mes?tipo=${encodeURIComponent(_pgTipo)}`, { credentials: 'include' });
       const data = await resp.json().catch(() => ({}));
       if (!resp.ok || data.ok === false) throw new Error(data.error || 'Erro ao carregar.');
 
@@ -14612,7 +14614,7 @@ document.querySelectorAll('#atTabelaWrapper thead th[data-col]').forEach(th => {
     if (status) { status.style.display = 'block'; status.textContent = 'Carregando...'; status.style.color = ''; }
 
     try {
-      const resp = await fetch('/api/sac/at/graficos/por-tag-problema-mes', { credentials: 'include' });
+      const resp = await fetch(`/api/sac/at/graficos/por-tag-problema-mes?tipo=${encodeURIComponent(_pgTipo)}`, { credentials: 'include' });
       const data = await resp.json().catch(() => ({}));
       if (!resp.ok || data.ok === false) throw new Error(data.error || 'Erro ao carregar.');
 
@@ -14690,7 +14692,7 @@ document.querySelectorAll('#atTabelaWrapper thead th[data-col]').forEach(th => {
     if (status) { status.style.display = 'block'; status.textContent = 'Carregando...'; status.style.color = ''; }
 
     try {
-      const resp = await fetch('/api/sac/at/graficos/por-estado-mes?tipo=Qualidade', { credentials: 'include' });
+      const resp = await fetch(`/api/sac/at/graficos/por-estado-mes?tipo=${encodeURIComponent(_pgTipo)}`, { credentials: 'include' });
       const data = await resp.json().catch(() => ({}));
       if (!resp.ok || data.ok === false) throw new Error(data.error || 'Erro ao carregar.');
 
@@ -14774,7 +14776,7 @@ document.querySelectorAll('#atTabelaWrapper thead th[data-col]').forEach(th => {
     }
   }
 
-  // ── Gráfico 2 — linhas (3 séries) ──────────────────────────────────────
+  // ── Gráfico 2 — linhas (3 séries com filtro de tipo) ───────────────────
   async function _carregarPg2() {
     const status = document.getElementById('atGrafPg2Status');
     const canvas = document.getElementById('atGrafPg2Canvas');
@@ -14816,16 +14818,15 @@ document.querySelectorAll('#atTabelaWrapper thead th[data-col]').forEach(th => {
       if (_pg2Instance) { _pg2Instance.destroy(); _pg2Instance = null; }
       const ctx = canvas.getContext('2d');
 
+      // Quando um tipo específico está selecionado, ocultar as outras séries
+      const _tipoLower = (_pgTipo || '').toLowerCase();
+      const dsQ = { label: 'Qualidade',              data: valQ, borderColor: '#34d399', backgroundColor: 'rgba(52,211,153,.10)', borderWidth: 2, pointRadius: 4, pointHoverRadius: 6, tension: 0.3, fill: true,  hidden: _tipoLower && _tipoLower !== 'qualidade' };
+      const dsR = { label: 'Atend. Rápido',          data: valR, borderColor: '#fb923c', backgroundColor: 'rgba(251,146,60,.10)',  borderWidth: 2, pointRadius: 4, pointHoverRadius: 6, tension: 0.3, fill: false, hidden: _tipoLower && !_tipoLower.startsWith('atendimento') };
+      const dsM = { label: 'Menções (OS não-rápido)', data: valM, borderColor: '#a855f7', backgroundColor: 'rgba(168,85,247,.10)',  borderWidth: 2, pointRadius: 4, pointHoverRadius: 6, tension: 0.3, fill: false, hidden: !!_tipoLower, borderDash: [5,4] };
+
       _pg2Instance = new Chart(ctx, {
         type: 'line',
-        data: {
-          labels,
-          datasets: [
-            { label: 'Qualidade',              data: valQ, borderColor: '#34d399', backgroundColor: 'rgba(52,211,153,.10)', borderWidth: 2, pointRadius: 4, pointHoverRadius: 6, tension: 0.3, fill: true },
-            { label: 'Atend. Rápido',          data: valR, borderColor: '#fb923c', backgroundColor: 'rgba(251,146,60,.10)',  borderWidth: 2, pointRadius: 4, pointHoverRadius: 6, tension: 0.3, fill: false },
-            { label: 'Menções (OS não-rápido)', data: valM, borderColor: '#a855f7', backgroundColor: 'rgba(168,85,247,.10)',  borderWidth: 2, pointRadius: 4, pointHoverRadius: 6, tension: 0.3, fill: false, borderDash: [5,4] },
-          ],
-        },
+        data: { labels, datasets: [dsQ, dsR, dsM] },
         options: {
           responsive: true,
           maintainAspectRatio: false,
@@ -14852,6 +14853,106 @@ document.querySelectorAll('#atTabelaWrapper thead th[data-col]').forEach(th => {
           scales: {
             x: { ticks: { color: '#94a3b8', font: { size: 11 } }, grid: { color: 'rgba(255,255,255,.05)' } },
             y: { beginAtZero: true, ticks: { color: '#94a3b8', stepSize: 1 }, grid: { color: 'rgba(255,255,255,.07)' } },
+          },
+        },
+      });
+      if (status) status.style.display = 'none';
+    } catch (err) {
+      if (status) { status.textContent = err.message || 'Erro.'; status.style.color = '#f87171'; }
+    }
+  }
+
+  // ── Gráfico 4 — Proporção OS / Vendas por Modelo ───────────────────────
+  async function _carregarPg4() {
+    const status = document.getElementById('atGrafPg4Status');
+    const canvas = document.getElementById('atGrafPg4Canvas');
+    if (!canvas) return;
+    if (status) { status.style.display = 'block'; status.textContent = 'Carregando...'; status.style.color = ''; }
+
+    try {
+      const tipoParam   = encodeURIComponent(_pgTipo || 'Qualidade');
+      const mesesParam  = _pgPeriodo > 0 ? _pgPeriodo : 36;
+      const resp = await fetch(`/api/sac/at/graficos/proporcao-modelo-vendas?tipo=${tipoParam}&meses=${mesesParam}`, { credentials: 'include' });
+      const data = await resp.json().catch(() => ({}));
+      if (!resp.ok || data.ok === false) throw new Error(data.error || 'Erro ao carregar.');
+
+      const rows = (data.rows || []).filter(r => r.qtd_vendida > 0).slice(0, 12);
+
+      if (_pg4Instance) { _pg4Instance.destroy(); _pg4Instance = null; }
+
+      if (!rows.length) {
+        if (status) { status.style.display = 'block'; status.textContent = 'Sem dados de proporção para o filtro selecionado.'; status.style.color = '#94a3b8'; }
+        return;
+      }
+
+      const labels   = rows.map(r => r.modelo);
+      const propData = rows.map(r => r.proporcao_pct !== null ? parseFloat(r.proporcao_pct) : 0);
+      const osData   = rows.map(r => r.os_count);
+      const vendData = rows.map(r => r.qtd_vendida);
+
+      const CORES = ['#f472b6','#fb923c','#ef4444','#a78bfa','#38bdf8','#34d399','#fbbf24','#6366f1','#10b981','#f59e0b','#84cc16','#06b6d4'];
+
+      const ctx = canvas.getContext('2d');
+      _pg4Instance = new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [{
+            label: '% OS por unidade vendida',
+            data: propData,
+            backgroundColor: CORES.map(c => c + 'cc'),
+            borderColor: CORES,
+            borderWidth: 1,
+            borderRadius: 5,
+          }],
+        },
+        plugins: [{
+          id: 'propLabels',
+          afterDatasetsDraw(chart) {
+            const ctx2 = chart.ctx;
+            chart.data.datasets.forEach((_ds, di) => {
+              const meta = chart.getDatasetMeta(di);
+              if (meta.hidden) return;
+              meta.data.forEach((bar, idx) => {
+                const val = chart.data.datasets[di].data[idx];
+                if (!val) return;
+                ctx2.save();
+                ctx2.font = 'bold 11px Segoe UI,Arial,sans-serif';
+                ctx2.fillStyle = '#e2e8f0';
+                ctx2.textAlign = 'center';
+                ctx2.textBaseline = 'bottom';
+                ctx2.fillText(val.toFixed(2) + '%', bar.x, bar.y - 2);
+                ctx2.restore();
+              });
+            });
+          },
+        }],
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label: (_item, idx) => {
+                  const i = _item.dataIndex;
+                  return [
+                    ` Proporção: ${propData[i].toFixed(2)}% (1 OS a cada ${propData[i] > 0 ? (100/propData[i]).toFixed(0) : '∞'} unidades)`,
+                    ` OS abertas: ${osData[i]}`,
+                    ` Unidades vendidas: ${vendData[i]}`,
+                  ];
+                },
+              },
+            },
+          },
+          scales: {
+            x: { ticks: { color: '#94a3b8', font: { size: 11 } }, grid: { color: 'rgba(255,255,255,.05)' } },
+            y: {
+              beginAtZero: true,
+              title: { display: true, text: '% OS / Vendas', color: '#64748b', font: { size: 11 } },
+              ticks: { color: '#94a3b8', callback: v => v + '%' },
+              grid: { color: 'rgba(255,255,255,.07)' },
+            },
           },
         },
       });
@@ -15310,11 +15411,30 @@ ${pivotHtml('Top 10 Modelos', '#0c4a6e', data.modelos)}
           _carregarPg01();
           _carregarPg1();
           _carregarPg2();
+          _carregarPg4();
+        });
+      });
+
+      // Botões de tipo
+      document.querySelectorAll('.at-graf-tipo-btn-pg').forEach(btn => {
+        btn.addEventListener('click', () => {
+          _pgTipo = btn.dataset.tipo || '';
+          document.querySelectorAll('.at-graf-tipo-btn-pg').forEach(b => {
+            const ativo = b === btn;
+            b.style.borderColor = ativo ? '#10b981' : '#374151';
+            b.style.background  = ativo ? 'rgba(16,185,129,.22)' : 'rgba(255,255,255,.04)';
+            b.style.color       = ativo ? '#6ee7b7' : '#9ca3af';
+          });
+          _carregarPg0();
+          _carregarPg01();
+          _carregarPg1();
+          _carregarPg2();
+          _carregarPg4();
         });
       });
 
       const refreshBtn = document.getElementById('atGrafPgRefreshBtn');
-      if (refreshBtn) refreshBtn.addEventListener('click', () => { _carregarPg0(); _carregarPg01(); _carregarPg1(); _carregarPg2(); });
+      if (refreshBtn) refreshBtn.addEventListener('click', () => { _carregarPg0(); _carregarPg01(); _carregarPg1(); _carregarPg2(); _carregarPg4(); });
 
       const relatorioBtn = document.getElementById('atGrafPgRelatorioBtn');
       if (relatorioBtn) relatorioBtn.addEventListener('click', _gerarRelatorioGrafAt);
@@ -15394,6 +15514,7 @@ ${pivotHtml('Top 10 Modelos', '#0c4a6e', data.modelos)}
     _carregarPg01();
     _carregarPg1();
     _carregarPg2();
+    _carregarPg4();
   };
 })();
 

--- a/routes/sacEnvios.js
+++ b/routes/sacEnvios.js
@@ -5916,21 +5916,78 @@ router.get('/at/graficos/por-modelo-mes', async (req, res) => {
 // GET /at/graficos/por-tag-problema-mes — quantidade de atendimentos por tag_problema agrupada por mês/ano
 router.get('/at/graficos/por-tag-problema-mes', async (req, res) => {
   try {
+    const tipo = String(req.query.tipo || '').trim();
+    const params = [];
+    const whereExtra = tipo ? ` AND LOWER(TRIM(tipo)) = LOWER($1)` : `\n        AND LOWER(TRIM(COALESCE(tipo, ''))) != 'atendimento rápido'`;
+    if (tipo) params.push(tipo);
+
     const { rows } = await pool.query(`
       SELECT
         COALESCE(NULLIF(TRIM(tag_problema), ''), '(sem tag)') AS tag_problema,
         TO_CHAR(DATE_TRUNC('month', data), 'YYYY-MM')         AS mes,
         COUNT(*)::int                                         AS total
       FROM sac.at
-      WHERE data IS NOT NULL
-        AND LOWER(TRIM(COALESCE(tipo, ''))) != 'atendimento rápido'
+      WHERE data IS NOT NULL${whereExtra}
       GROUP BY 1, 2
       ORDER BY 2, 1
-    `);
+    `, params);
 
     return res.json({ ok: true, rows });
   } catch (err) {
     console.error('[SAC/AT] erro graficos por-tag-problema-mes:', err);
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// GET /at/graficos/proporcao-modelo-vendas — proporção OS/vendas por modelo
+router.get('/at/graficos/proporcao-modelo-vendas', async (req, res) => {
+  try {
+    const tipo  = String(req.query.tipo  || 'Qualidade').trim();
+    const meses = parseInt(req.query.meses || '3', 10);
+    const params = [tipo];
+    const whereData = meses > 0
+      ? `AND a.data >= DATE_TRUNC('month', CURRENT_DATE) - INTERVAL '${meses} months'
+         AND a.data <  DATE_TRUNC('month', CURRENT_DATE)`
+      : '';
+
+    const { rows } = await pool.query(`
+      WITH os_por_modelo AS (
+        SELECT
+          UPPER(TRIM(COALESCE(a.modelo, ''))) AS modelo,
+          COUNT(*)::int                        AS os_count
+        FROM sac.at a
+        WHERE LOWER(TRIM(a.tipo)) = LOWER($1)
+          AND TRIM(COALESCE(a.modelo, '')) != ''
+          ${whereData}
+        GROUP BY 1
+      ),
+      vendas_por_modelo AS (
+        SELECT
+          UPPER(TRIM(i.codigo))  AS modelo,
+          SUM(i.quantidade)      AS qtd_vendida
+        FROM "Vendas".pedidos_venda_itens i
+        JOIN "Vendas".pedidos_venda p ON p.codigo_pedido = i.codigo_pedido
+        WHERE TRIM(p.etapa::text) IN ('70','80')
+          AND TRIM(COALESCE(i.codigo, '')) != ''
+        GROUP BY 1
+      )
+      SELECT
+        o.modelo,
+        o.os_count,
+        COALESCE(v.qtd_vendida, 0)::int                               AS qtd_vendida,
+        CASE WHEN COALESCE(v.qtd_vendida, 0) > 0
+          THEN ROUND(o.os_count::numeric / v.qtd_vendida * 100, 2)
+          ELSE NULL
+        END AS proporcao_pct
+      FROM os_por_modelo o
+      LEFT JOIN vendas_por_modelo v ON v.modelo = o.modelo
+      ORDER BY o.os_count DESC
+      LIMIT 15
+    `, params);
+
+    return res.json({ ok: true, rows });
+  } catch (err) {
+    console.error('[SAC/AT] erro graficos proporcao-modelo-vendas:', err);
     return res.status(500).json({ ok: false, error: err.message });
   }
 });


### PR DESCRIPTION
## Mudanças\n\n### Backend (routes/sacEnvios.js)\n- Endpoint `por-tag-problema-mes`: aceita parâmetro `?tipo=`; sem tipo, exclui atendimento rápido\n- Novo endpoint `GET /at/graficos/proporcao-modelo-vendas?tipo=X&meses=Y`: cruza OS de `sac.at` com vendas (etapas 70/80) e calcula % OS por unidade vendida\n\n### Frontend (menu_produto.html)\n- Toolbar com botões de tipo: Qualidade (ativo por padrão, verde), Atendimento Rápido, Todos\n- Nova ordem dos gráficos: 1=Top Modelos, 2=Picos, 3=Estado/Mês, 4=Proporção OS/Vendas\n- Gráfico 4 com canvas `atGrafPg4Canvas` e subtítulo explicativo\n\n### Frontend (menu_produto.js)\n- Variável `_pgTipo` (padrão `Qualidade`) controla filtro de tipo\n- Todos os loaders (`_carregarPg0/01/1/2`) passam `_pgTipo` como query param\n- `_carregarPg2`: oculta séries não relevantes quando um tipo está selecionado\n- Nova função `_carregarPg4()`: renderiza gráfico de barras verticais com proporção % por modelo\n- `_iniciarGrafAtPagina`: adiciona listeners dos botões de tipo; todos os botões (período, tipo, refresh) chamam `_carregarPg4()`