### PR TITLE
fix(recebimento): ajustar associacao nfe agrupada

### DIFF
--- a/colaborador-fluxo-branch-seguro.instructions.md
+++ b/colaborador-fluxo-branch-seguro.instructions.md
@@ -1,0 +1,127 @@
+---
+applyTo: '**'
+---
+# Guia para IA do colaborador — Fluxo seguro de branch e PR
+
+## Contexto do repositório
+Este projeto é editado por múltiplos colaboradores usando GitHub Copilot no VS Code.
+O repositório tem arquivos grandes e críticos (`menu_produto.js`, `menu_produto.html`, `server.js`)
+que são frequentemente modificados em paralelo por colaboradores diferentes.
+
+**Já houve perda real de funcionalidades** por branches desatualizados sendo mergeados.
+Siga rigorosamente este guia em toda tarefa.
+
+---
+
+## ⚠️ Regra de ouro — NUNCA trabalhar em branch desatualizado
+
+Antes de começar qualquer tarefa, a IA deve obrigatoriamente executar:
+
+```bash
+git status --short
+git fetch origin
+git log HEAD..origin/main --oneline
+```
+
+Se o branch local estiver atrás do `main` remoto:
+
+```bash
+git merge origin/main
+```
+
+Resolver conflitos se houver, validar sintaxe e só então começar a trabalhar.
+
+---
+
+## Fluxo obrigatório — do início ao PR
+
+### 1. Preparar o branch
+```bash
+# Sempre partir do main atualizado
+git checkout main
+git pull origin main
+
+# Criar branch com nome descritivo
+git checkout -b feat/descricao-curta
+```
+
+### 2. Fazer as alterações
+- Editar apenas os arquivos relacionados à tarefa solicitada
+- Não reformatar, não reordenar, não "limpar" código fora do escopo
+- Validar sintaxe após cada arquivo JS alterado:
+  ```bash
+  node --check server.js
+  node --check menu_produto.js
+  ```
+
+### 3. ANTES de abrir o PR — atualizar com o main atual
+```bash
+git fetch origin
+git merge origin/main
+```
+
+Se houver conflitos:
+- Resolver manualmente preservando AMBAS as funcionalidades (a do main E a do branch)
+- Nunca descartar blocos sem entender o que fazem
+- Validar sintaxe novamente após resolver
+- Fazer commit da resolução
+
+### 4. Abrir o PR
+- Título claro no formato: `tipo(area): descrição` (ex: `fix(recebimento): corrigir valor unitário`)
+- Descrever **o que mudou**, **por que** e **como validar**
+- Listar os arquivos alterados
+
+---
+
+## Arquivos de alto risco — atenção redobrada
+
+| Arquivo | Risco |
+|---|---|
+| `menu_produto.html` | Contém painéis inteiros que podem ser sobrescritos silenciosamente |
+| `menu_produto.js` | ~63k linhas; features inteiras podem sumir sem conflito visível |
+| `server.js` | Arquivo de alto conflito; editar somente o bloco necessário |
+
+### Verificações obrigatórias após `git merge origin/main` nesses arquivos:
+
+```bash
+# Painel 1ª Peça OK — deve retornar > 0
+grep -c "producaoPrimeiraPecaOkPane" menu_produto.html
+
+# Filtro tipo no Gráfico AT — deve retornar > 0
+grep -c "_pgTipo" menu_produto.js
+
+# Toolbar Gráfico AT — deve retornar > 0
+grep -c "sacAtGraficosPane" menu_produto.html
+
+# Relatório PDF Gráfico AT — deve retornar > 0
+grep -c "_gerarRelatorioGrafAt" menu_produto.js
+```
+
+Se algum retornar `0`, a feature foi perdida no merge. **Não subir o PR.** Recuperar a feature do `origin/main` antes de continuar.
+
+---
+
+## O que a IA NÃO deve fazer
+
+- ❌ Começar a editar arquivos sem checar `git status` e `git fetch` primeiro
+- ❌ Fazer `git push` ou abrir PR sem antes executar `git merge origin/main`
+- ❌ Resolver conflito descartando blocos sem ler o conteúdo
+- ❌ Commitar `server.js` inteiro reformatado junto com uma feature pontual
+- ❌ Ignorar resultados `0` nas verificações de features críticas acima
+- ❌ Commitar segredos, `.env`, tokens ou credenciais
+
+---
+
+## Formato de commit
+
+```
+tipo(area): descrição curta
+
+- detalhe do que foi feito
+- motivo da mudança
+```
+
+Exemplos válidos:
+- `fix(recebimento): corrigir unidade na associacao nfe-pedido`
+- `feat(logistica): adicionar campo cod_local na separacao`
+- `chore(server): remover console.log de debug`

--- a/menu_produto.html
+++ b/menu_produto.html
@@ -9015,7 +9015,7 @@
   <!-- Interceptor de sessão: precisa carregar ANTES de qualquer módulo que faça fetch -->
   <script src="/public/js/sessao_resiliente.js?v=20260422a"></script>
   <script type="module" src="login/login.js"></script>
-  <script type="module" src="menu_produto.js?v=20260507a"></script>
+  <script type="module" src="menu_produto.js?v=20260513b"></script>
   
   <script type="module" src="./requisicoes_omie/filtro_produto.js"></script>
   <script type="module" src="./requisicoes_omie/ListarProdutos.js"></script>
@@ -13110,9 +13110,11 @@ function attachDropZone(ul) {
   window.fecharModalLocalizarNfe = fecharModal;
 
   btnFechar && btnFechar.addEventListener('click', fecharModal);
-  modal.addEventListener('click', (e) => { if (e.target === modal) fecharModal(); });
-  document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape' && modal.style.display === 'block') fecharModal();
+  modal.addEventListener('click', (e) => {
+    if (e.target === modal) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
   });
 
   // ── Utilitários ──────────────────────────────────────────────
@@ -13302,6 +13304,25 @@ function attachDropZone(ul) {
     return '<span style="background:#fff7ed;color:#c2410c;border:1px solid #fed7aa;border-radius:6px;padding:2px 8px;font-size:11px;font-weight:700;">Faturada (etapa '+esc(c||'-')+')</span>';
   };
 
+  const nfeJaRecebidaOuConcluida = (nfe) => {
+    const etapa = String(nfe?.c_etapa || '').trim();
+    const recebido = String(nfe?.c_recebido || '').toUpperCase() === 'S';
+    const desc = String(nfe?.c_etapa_descricao || nfe?.etapa_descricao || nfe?.status || '').normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+    return recebido || etapa === '60' || etapa === '80' || desc.includes('concluid') || desc.includes('recebid');
+  };
+
+  const renderAvisoNfeSomenteConsulta = (nfe) => {
+    const etapa = esc(nfe?.c_etapa || '-');
+    const label = String(nfe?.c_etapa || '').trim() === '80' ? 'NF-e concluida' : `NF-e recebida (etapa ${etapa})`;
+    return `<div style="margin:0 0 12px;padding:14px 16px;border:2px solid #86efac;background:#ecfdf5;color:#14532d;border-radius:10px;display:flex;align-items:flex-start;gap:12px;">
+      <i class="fa-solid fa-circle-check" style="font-size:22px;color:#16a34a;margin-top:1px;"></i>
+      <div>
+        <div style="font-size:16px;font-weight:800;line-height:1.2;">${label}</div>
+        <div style="font-size:12px;margin-top:4px;color:#166534;">Esta nota ja foi recebida/concluida. A tela fica somente para consulta; pedidos sugeridos e nova associacao ficam ocultos ate a NF-e voltar de etapa.</div>
+      </div>
+    </div>`;
+  };
+
   // ── Card de pedido reutilizável ───────────────────────────────
   const renderPedidoCard = (ped, chaveNfe, numeroNfe, badgeExtra, justEl) => {
     badgeExtra = badgeExtra || '';
@@ -13338,7 +13359,6 @@ function attachDropZone(ul) {
         const numeroNfe= card.dataset.numeroNfe|| '';
         let itensCard = [];
         try { itensCard = JSON.parse(card.dataset.itens || '[]'); } catch (_) {}
-        fecharModal();
         if (window.abrirModalAssociarPedidoNfeComContexto) {
           window.abrirModalAssociarPedidoNfeComContexto({
             numero_nfe: numeroNfe, numero_pedido: cnumero,
@@ -13376,6 +13396,7 @@ function attachDropZone(ul) {
       ultimaNfeCtx = { nfe, itens };
 
       const jaVinculado  = itens.some(i => i.n_id_pedido && Number(i.n_id_pedido) > 0);
+      const somenteConsulta = nfeJaRecebidaOuConcluida(nfe);
       const totalItens   = itens.reduce((acc, i) => acc + (Number(i.vlr_item) || 0), 0);
       const statusHtml   = renderEtapaBadge(nfe.c_etapa, nfe.c_recebido, nfe.c_cancelada);
 
@@ -13397,7 +13418,9 @@ function attachDropZone(ul) {
       </div>`;
 
       let pedidosHtml = '';
-      if (pedidos.length > 0) {
+      if (somenteConsulta) {
+        pedidosHtml = '';
+      } else if (pedidos.length > 0) {
         // Calcula score local e ordena antes de renderizar
         const pedidosComScore = pedidos.map(ped => ({
           ...ped,
@@ -13427,7 +13450,7 @@ function attachDropZone(ul) {
         pedidosHtml = '<div style="padding:10px;background:#f8fafc;border:1px solid #e2e8f0;color:#64748b;border-radius:8px;font-size:13px;"><i class="fa-solid fa-info-circle" style="margin-right:6px;"></i>Nenhum pedido de compra correspondente localizado.</div>';
       }
 
-      conteudo.innerHTML = cabecHtml + pedidosHtml;
+      conteudo.innerHTML = (somenteConsulta ? renderAvisoNfeSomenteConsulta(nfe) : '') + cabecHtml + pedidosHtml;
       attachCardListeners();
 
       const btnRanquear = document.getElementById('locNfeBtnRanquear');

--- a/menu_produto.js
+++ b/menu_produto.js
@@ -6935,10 +6935,21 @@ document.getElementById('menu-solicitacao-transferencia')?.addEventListener('cli
   await window.openSolicitacoesTransferencia?.();
 });
 
+function abrirLocalizarNfePeloMenuRecebimento() {
+  const inputNfe = document.getElementById('modalLocalizarNfeInput');
+  const inputPedido = document.getElementById('modalLocalizarPedidoInput');
+  if (inputNfe) inputNfe.value = '';
+  if (inputPedido) inputPedido.value = '';
+  document.getElementById('locNfeTabNfe')?.click();
+  if (typeof window.abrirModalLocalizarNfe === 'function') {
+    window.abrirModalLocalizarNfe();
+  }
+}
+
 document.getElementById('menu-recebimento')?.addEventListener('click', async e => {
   e.preventDefault();
-  showMainTab('recebimentoPane');
-  // await loadComprasRecebimento(); // COMENTADO - usando nova implementação inline no HTML
+  e.stopImmediatePropagation();
+  abrirLocalizarNfePeloMenuRecebimento();
 });
 
 // QUALIDADE: abre painel de Qualidade Fábrica
@@ -42939,7 +42950,8 @@ function vincularFiltrosRecebimento() {
 
   document.getElementById('menu-recebimento')?.addEventListener('click', async (event) => {
     event.preventDefault();
-    await loadComprasRecebimento();
+    event.stopImmediatePropagation();
+    abrirLocalizarNfePeloMenuRecebimento();
   });
 
   document.getElementById('recebimentoRefreshBtn')?.addEventListener('click', async () => {
@@ -47251,7 +47263,18 @@ function setStatusModalAssociarPedidoNfe(mensagem, tipo = 'info') {
   statusEl.style.background = tema.bg;
   statusEl.style.border = `1px solid ${tema.border}`;
   statusEl.style.color = tema.color;
-  statusEl.textContent = mensagem || '';
+  if (mensagem && /^<div\s/i.test(String(mensagem).trim())) {
+    statusEl.innerHTML = mensagem;
+  } else {
+    statusEl.textContent = mensagem || '';
+  }
+}
+
+function resetBotaoAssociarPedidoNfe(disabled = true) {
+  const btnAssociar = document.getElementById('modalAssociarPedidoBtnConfirmar');
+  if (!btnAssociar) return;
+  btnAssociar.disabled = disabled;
+  btnAssociar.innerHTML = '<i class="fa-solid fa-check"></i> Associar';
 }
 
 async function carregarSeletorCategoriasAssociarNfe(categoriaAtualCodigo, categoriaAtualDescricao) {
@@ -47459,7 +47482,7 @@ function snapshotEdicoesQtdUnidAssociacaoNfe() {
     window.__associarNfeCamposEditados = {};
   }
 
-  previewConteudo.querySelectorAll('.assoc-override-qtd, .assoc-override-unid').forEach((input) => {
+  previewConteudo.querySelectorAll('.assoc-override-qtd, .assoc-override-unid, .assoc-override-valor').forEach((input) => {
     const seq = Number(input.dataset.seq || 0);
     if (!seq) return;
 
@@ -47474,6 +47497,11 @@ function snapshotEdicoesQtdUnidAssociacaoNfe() {
 
     if (input.classList.contains('assoc-override-unid')) {
       window.__associarNfeCamposEditados[seq].cUnidade = String(input.value || '').trim().toUpperCase() || null;
+    }
+
+    if (input.classList.contains('assoc-override-valor')) {
+      const valor = parseFloat(String(input.value || '').replace(/\./g, '').replace(',', '.'));
+      window.__associarNfeCamposEditados[seq].nValTot = Number.isFinite(valor) ? valor : null;
     }
   });
 }
@@ -47620,17 +47648,25 @@ function renderPreviewAssociacaoPedidoNfe(preview) {
   const itensSemMatch = itens.length - itensComMatch;
 
   const divergenciasValor = itens.filter((item) => {
+    if (item?.criterio_match === 'agrupamento_mesmo_item_pedido') return false;
     const nfValor = Number(item?.nf_valor_total || 0);
     const pedidoValor = Number(item?.pedido_valor_total || 0);
     return Number.isFinite(nfValor) && Number.isFinite(pedidoValor) && Math.abs(nfValor - pedidoValor) > 0.01;
   }).length;
   const divergenciasQtdUnid = itens.filter((item) => {
+    if (item?.criterio_match === 'agrupamento_mesmo_item_pedido') return false;
     const unidadePedido = obterUnidadePedidoPreviewAssociacao(item);
     return compararQuantidadePreview(item) || compararUnidadePreview(item, unidadePedido);
   }).length;
+  const gruposMesmoItem = itens.filter((item) => item?.criterio_match === 'agrupamento_mesmo_item_pedido').length;
 
   const totalValorNfPreview = itens.reduce((acc, item) => acc + (Number(item?.nf_valor_total || 0) || 0), 0);
-  const totalValorPedidoPreview = itens.reduce((acc, item) => acc + (Number(item?.pedido_valor_total || 0) || 0), 0);
+  const totalValorPedidoPreview = itens.reduce((acc, item) => {
+    const seq = Number(item?.n_sequencia || 0);
+    const overrideCampos = window.__associarNfeCamposEditados?.[seq] || {};
+    const valorOverride = Number(overrideCampos?.nValTot);
+    return acc + (Number.isFinite(valorOverride) ? valorOverride : (Number(item?.pedido_valor_total || 0) || 0));
+  }, 0);
 
   const resumoHtml = `
     <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:8px;margin-bottom:10px;">
@@ -47675,19 +47711,25 @@ function renderPreviewAssociacaoPedidoNfe(preview) {
               ? 'Ajuste manual'
             : item?.criterio_match === 'fallback_item_unico_pedido'
               ? 'Item único do pedido'
+            : item?.criterio_match === 'agrupamento_mesmo_item_pedido'
+              ? 'Item agrupado'
               : (encontrou ? 'Match identificado' : 'Sem match');
         const nfValor = Number(item?.nf_valor_total || 0);
         const pedidoValor = Number((isServico ? item?.nf_valor_total : item?.pedido_valor_total) || 0);
+        const agrupadoMesmoItem = item?.criterio_match === 'agrupamento_mesmo_item_pedido';
         const divergiuValor = Number.isFinite(nfValor) && Number.isFinite(pedidoValor) && Math.abs(nfValor - pedidoValor) > 0.01;
         const seq = Number(item?.n_sequencia || 0);
         const overrideCampos = window.__associarNfeCamposEditados?.[seq] || {};
         const qtdPedidoBase = item?.pedido_qtde ?? '-';
         const qtdPedido = isServico ? (item?.nf_qtde ?? '-') : (overrideCampos?.nQtde ?? qtdPedidoBase);
+        const valorPedidoEditado = isServico ? item?.nf_valor_total : (overrideCampos?.nValTot ?? item?.pedido_valor_total);
         const unidadePedidoBase = obterUnidadePedidoPreviewAssociacao(item);
         const unidadePedido = isServico ? (item?.nf_unidade || '-') : (overrideCampos?.cUnidade || unidadePedidoBase);
-        const divergiuQtd = compararQuantidadePreview({ ...item, pedido_qtde: qtdPedido });
-        const divergiuUnidade = compararUnidadePreview(item, unidadePedido);
-        const temDivergencia = divergiuValor || divergiuQtd || divergiuUnidade;
+        const divergiuQtd = !isServico && !agrupadoMesmoItem && compararQuantidadePreview({ ...item, pedido_qtde: qtdPedido });
+        const divergiuUnidade = !isServico && !agrupadoMesmoItem && compararUnidadePreview(item, unidadePedido);
+        const pedidoValorComparacao = Number(valorPedidoEditado || 0);
+        const divergiuValorEditado = !isServico && !agrupadoMesmoItem && Number.isFinite(nfValor) && Number.isFinite(pedidoValorComparacao) && Math.abs(nfValor - pedidoValorComparacao) > 0.01;
+        const temDivergencia = divergiuValorEditado || divergiuQtd || divergiuUnidade;
         const qtdNf = item?.nf_qtde ?? '-';
         const corQtd = divergiuQtd ? '#b91c1c' : '#0f172a';
         const bgQtd = divergiuQtd ? '#fee2e2' : 'transparent';
@@ -47730,7 +47772,11 @@ function renderPreviewAssociacaoPedidoNfe(preview) {
                 ? `<input type="text" class="assoc-override-unid" data-seq="${seq}" value="${escapeHtml(String(unidadePedido || ''))}" style="width:50px;padding:2px 4px;font-size:11px;font-weight:700;color:#b91c1c;border:1px solid #fca5a5;border-radius:4px;text-align:center;background:#fff5f5;text-transform:uppercase;" title="Edite a unidade para associação">`
                 : escapeHtml(String(unidadePedido || '-'))
             }</td>
-            <td style="padding:7px 8px;font-size:11px;text-align:right;font-weight:700;color:${divergiuValor ? '#b91c1c' : '#0f172a'};background:${divergiuValor ? '#fee2e2' : 'transparent'};">${escapeHtml(formatarValorRecebimento(isServico ? item?.nf_valor_total : item?.pedido_valor_total))}</td>
+            <td style="padding:7px 8px;font-size:11px;text-align:right;font-weight:700;color:${divergiuValorEditado ? '#b91c1c' : '#0f172a'};background:${divergiuValorEditado ? '#fee2e2' : 'transparent'};">${
+              divergiuValorEditado
+                ? `<input type="text" class="assoc-override-valor" data-seq="${seq}" value="${escapeHtml(Number(valorPedidoEditado || 0).toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 }))}" style="width:82px;padding:2px 4px;font-size:11px;font-weight:700;color:#b91c1c;border:1px solid #fca5a5;border-radius:4px;text-align:right;background:#fff5f5;" title="Edite o valor total do item do pedido">`
+                : escapeHtml(formatarValorRecebimento(valorPedidoEditado))
+            }</td>
             <td style="padding:7px 8px;font-size:11px;text-align:center;color:${temDivergencia ? '#b91c1c' : (encontrou ? '#166534' : '#9a3412')};font-weight:700;">${escapeHtml(criterio)}</td>
           </tr>
         `;
@@ -47739,6 +47785,7 @@ function renderPreviewAssociacaoPedidoNfe(preview) {
 
   previewConteudo.innerHTML = `
     ${resumoHtml}
+    ${gruposMesmoItem > 0 ? `<div style="margin:0 0 10px;padding:10px 12px;border:1px solid #bbf7d0;background:#ecfdf5;color:#166534;border-radius:8px;font-size:12px;font-weight:700;"><i class="fa-solid fa-layer-group" style="margin-right:6px;"></i>${gruposMesmoItem} linha(s) da NF-e foram agrupadas no mesmo item do pedido. A conferência usa a soma das linhas, não cada linha isolada.</div>` : ''}
     <div style="margin:0 0 10px;padding:9px 12px;border:1px solid #bae6fd;background:#f0f9ff;color:#0c4a6e;border-radius:8px;font-size:12px;font-weight:700;">Arraste o bloco do item do Pedido (coluna azul com ícone <i class="fa-solid fa-grip-vertical"></i>) para outra linha da NF-e para trocar a associação.</div>
     ${(divergenciasValor > 0 || divergenciasQtdUnid > 0) ? `<div style="margin:0 0 10px;padding:10px 12px;border:1px solid #fecaca;background:#fff1f2;color:#b91c1c;border-radius:8px;font-size:12px;font-weight:700;">Existem divergências de valor, quantidade ou unidade entre a NF-e e o pedido.${divergenciasQtdUnid > 0 ? ' Edite os campos de Qtd/Unid. do Pedido (em vermelho) antes de associar.' : ' Os campos divergentes estão destacados em vermelho.'}</div>` : ''}
     <div style="max-height:340px;overflow:auto;border:1px solid #e2e8f0;border-radius:10px;">
@@ -47774,7 +47821,7 @@ function renderPreviewAssociacaoPedidoNfe(preview) {
 
   previewWrap.style.display = 'block';
   habilitarDragDropAssociacaoPedidoNfe(preview);
-  previewConteudo.querySelectorAll('.assoc-override-qtd, .assoc-override-unid').forEach((input) => {
+  previewConteudo.querySelectorAll('.assoc-override-qtd, .assoc-override-unid, .assoc-override-valor').forEach((input) => {
     input.addEventListener('input', snapshotEdicoesQtdUnidAssociacaoNfe);
     input.addEventListener('change', snapshotEdicoesQtdUnidAssociacaoNfe);
   });
@@ -47928,10 +47975,10 @@ async function previsualizarAssociacaoPedidoNfeOmie() {
         `Prévia gerada. ${qtdSemMatch} item(ns) da NF-e não foram mapeados ao pedido — revise antes de confirmar.`,
         'erro'
       );
-      btnAssociar.disabled = true;
+      resetBotaoAssociarPedidoNfe(true);
     } else {
       setStatusModalAssociarPedidoNfe('Prévia gerada. Itens prontos para associação.', 'sucesso');
-      btnAssociar.disabled = false;
+      resetBotaoAssociarPedidoNfe(false);
     }
   } catch (err) {
     setStatusModalAssociarPedidoNfe(err?.message || 'Erro ao gerar prévia de associação.', 'erro');
@@ -48053,7 +48100,7 @@ async function confirmarAssociacaoPedidoNfeOmie() {
     return;
   }
 
-  const textoOriginal = btnAssociar.innerHTML;
+  let associacaoConcluida = false;
   btnAssociar.disabled = true;
   btnAssociar.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i>';
   setStatusModalAssociarPedidoNfe('Associando NF-e ao pedido na Omie...', 'info');
@@ -48088,7 +48135,7 @@ async function confirmarAssociacaoPedidoNfeOmie() {
 
     const previewConteudo = document.getElementById('modalAssociarPedidoNfePreviewConteudo');
     if (previewConteudo) {
-      previewConteudo.querySelectorAll('.assoc-override-qtd, .assoc-override-unid').forEach(input => {
+      previewConteudo.querySelectorAll('.assoc-override-qtd, .assoc-override-unid, .assoc-override-valor').forEach(input => {
         const seq = Number(input.dataset.seq || 0);
         if (!seq) return;
         let entry = itensOverrideMap.get(seq);
@@ -48101,6 +48148,10 @@ async function confirmarAssociacaoPedidoNfeOmie() {
         }
         if (input.classList.contains('assoc-override-unid')) {
           entry.cUnidade = String(input.value || '').trim().toUpperCase() || null;
+        }
+        if (input.classList.contains('assoc-override-valor')) {
+          const valor = parseFloat(String(input.value || '').replace(/\./g, '').replace(',', '.'));
+          entry.nValTot = Number.isFinite(valor) ? valor : null;
         }
       });
     }
@@ -48128,11 +48179,43 @@ async function confirmarAssociacaoPedidoNfeOmie() {
     if (!resp.ok || !data?.ok) {
       throw new Error(data?.error || `Falha ao associar NF-e (HTTP ${resp.status})`);
     }
+    associacaoConcluida = true;
 
     setStatusModalAssociarPedidoNfe(
-      data?.message || `NF-e ${numeroNfe} associada com sucesso ao pedido ${numeroPedido}.`,
+      `<div style="display:flex;align-items:flex-start;gap:12px;">
+        <i class="fa-solid fa-circle-check" style="font-size:26px;color:#16a34a;margin-top:2px;"></i>
+        <div style="flex:1;">
+          <div style="font-size:17px;font-weight:800;line-height:1.2;">NF-e associada com sucesso</div>
+          <div style="font-size:13px;margin-top:5px;">${escapeHtml(data?.message || `NF-e ${numeroNfe} associada ao pedido ${numeroPedido}.`)}</div>
+          <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:12px;">
+            <button type="button" id="modalAssociarNovaBuscaBtn" style="border:none;border-radius:8px;background:#7c3aed;color:#fff;font-weight:700;padding:9px 13px;cursor:pointer;display:inline-flex;align-items:center;gap:6px;">
+              <i class="fa-solid fa-magnifying-glass"></i> Buscar outra NF-e
+            </button>
+            <button type="button" id="modalAssociarFecharSucessoBtn" style="border:1px solid #86efac;border-radius:8px;background:#ffffff;color:#166534;font-weight:700;padding:9px 13px;cursor:pointer;">
+              Fechar
+            </button>
+          </div>
+        </div>
+      </div>`,
       'sucesso'
     );
+
+    document.getElementById('modalAssociarNovaBuscaBtn')?.addEventListener('click', () => {
+      fecharModalAssociarPedidoNfe();
+      if (typeof window.abrirModalLocalizarNfe === 'function') {
+        window.abrirModalLocalizarNfe();
+      }
+      const inputLocalizar = document.getElementById('modalLocalizarNfeInput');
+      if (inputLocalizar) {
+        inputLocalizar.value = '';
+        inputLocalizar.focus();
+      }
+      const conteudoLocalizar = document.getElementById('modalLocalizarNfeConteudo');
+      if (conteudoLocalizar) {
+        conteudoLocalizar.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;color:#94a3b8;font-size:13px;padding:24px 0;gap:8px;"><i class="fa-solid fa-file-invoice"></i><span>Digite o numero da NF-e e clique em Buscar.</span></div>';
+      }
+    });
+    document.getElementById('modalAssociarFecharSucessoBtn')?.addEventListener('click', fecharModalAssociarPedidoNfe);
 
     if (typeof loadComprasRecebimento === 'function') {
       loadComprasRecebimento(true).catch(() => {});
@@ -48143,8 +48226,12 @@ async function confirmarAssociacaoPedidoNfeOmie() {
   } catch (err) {
     setStatusModalAssociarPedidoNfe(err?.message || 'Erro ao associar NF-e ao pedido.', 'erro');
   } finally {
-    btnAssociar.disabled = false;
-    btnAssociar.innerHTML = textoOriginal;
+    if (associacaoConcluida) {
+      btnAssociar.disabled = true;
+      btnAssociar.innerHTML = '<i class="fa-solid fa-circle-check"></i> Associado';
+    } else {
+      resetBotaoAssociarPedidoNfe(false);
+    }
   }
 }
 
@@ -48234,7 +48321,7 @@ function criarModalAssociarPedidoNfeSeNecessario() {
   document.getElementById('modalAssociarPedidoBtnConfirmar')?.addEventListener('click', confirmarAssociacaoPedidoNfeOmie);
 
   const btnAssociar = document.getElementById('modalAssociarPedidoBtnConfirmar');
-  if (btnAssociar) btnAssociar.disabled = true;
+  resetBotaoAssociarPedidoNfe(true);
 
   const inputNfe = document.getElementById('modalAssociarNfeNumeroInput');
   inputNfe?.addEventListener('keydown', (ev) => {
@@ -48246,8 +48333,7 @@ function criarModalAssociarPedidoNfeSeNecessario() {
 
   const inputPedido = document.getElementById('modalAssociarPedidoNumeroInput');
   inputPedido?.addEventListener('input', () => {
-    const btnAssociar = document.getElementById('modalAssociarPedidoBtnConfirmar');
-    if (btnAssociar) btnAssociar.disabled = true;
+    resetBotaoAssociarPedidoNfe(true);
     if (window.__associarNfePreviewAtual) window.__associarNfePreviewAtual = null;
   });
   inputPedido?.addEventListener('keydown', (ev) => {
@@ -48291,6 +48377,7 @@ async function abrirModalAssociarPedidoNfeComContexto(contexto = {}) {
   if (pedidoInput) pedidoInput.value = String(contexto?.numero_pedido || '').trim();
   if (blocoPedido) blocoPedido.style.display = 'block';
   if (btnAssociar) btnAssociar.disabled = true;
+  resetBotaoAssociarPedidoNfe(true);
 
   setStatusModalAssociarPedidoNfe('Prévia profissional carregando para revisão da vinculação...', 'info');
 

--- a/server.js
+++ b/server.js
@@ -13606,6 +13606,126 @@ function inferNotaEntradaStatusFromTopic(topic = '') {
   return 'Desconhecida';
 }
 
+function normalizarTextoWebhookRecebimento(valor = '') {
+  return String(valor || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim();
+}
+
+function topicRecebimentoConcluido(topic = '') {
+  return normalizarTextoWebhookRecebimento(topic).includes('concluid');
+}
+
+function topicRecebimentoRevertido(topic = '') {
+  return normalizarTextoWebhookRecebimento(topic).includes('revertid');
+}
+
+function extrairNumeroPedidoCompraRecebimento(texto = '') {
+  const normalizado = String(texto || '').trim();
+  if (!normalizado) return null;
+
+  const padroes = [
+    /pedido\s*de\s*compra\s*(?:numero|n[uú]mero|n[ºo.]?)?\s*[-:#]?\s*(\d+)/i,
+    /pedido\s*(?:numero|n[uú]mero|n[ºo.]?)?\s*[-:#]?\s*(\d+)/i,
+    /\bpc\s*[-:#]?\s*(\d+)\b/i
+  ];
+
+  for (const padrao of padroes) {
+    const match = normalizado.match(padrao);
+    if (match?.[1]) return match[1].replace(/^0+/, '') || '0';
+  }
+
+  return null;
+}
+
+async function ensurePedidoRecebidoWebhookColumns(db = pool) {
+  await db.query(`
+    ALTER TABLE compras.pedidos_omie
+      ADD COLUMN IF NOT EXISTS "Pedido recebido" BOOLEAN DEFAULT FALSE,
+      ADD COLUMN IF NOT EXISTS "Pedido recebido em" TIMESTAMP NULL,
+      ADD COLUMN IF NOT EXISTS "Pedido recebido webhook" TEXT NULL
+  `);
+}
+
+async function atualizarPedidoRecebidoPorWebhookRecebimento(db, {
+  topic = '',
+  nIdReceb = null,
+  numeroPedido = null,
+  cDadosAdicionais = null,
+  messageId = null
+} = {}) {
+  const concluido = topicRecebimentoConcluido(topic);
+  const revertido = topicRecebimentoRevertido(topic);
+  if (!concluido && !revertido) return { ok: true, updated: 0, skipped: 'topic_sem_alteracao_pedido' };
+
+  await ensurePedidoRecebidoWebhookColumns(db);
+
+  const pedidos = new Set();
+  const numeroExtraido = numeroPedido || extrairNumeroPedidoCompraRecebimento(cDadosAdicionais);
+  if (numeroExtraido) pedidos.add(String(numeroExtraido));
+
+  if (nIdReceb) {
+    const { rows } = await db.query(`
+      SELECT DISTINCT n_id_pedido::text AS n_id_pedido
+        FROM logistica.recebimentos_nfe_itens
+       WHERE n_id_receb = $1
+         AND n_id_pedido IS NOT NULL
+    `, [nIdReceb]);
+    rows.forEach((row) => {
+      if (row.n_id_pedido) pedidos.add(String(row.n_id_pedido));
+    });
+  }
+
+  if (pedidos.size === 0) return { ok: true, updated: 0, skipped: 'pedido_nao_identificado' };
+
+  const valores = Array.from(pedidos);
+  const pedidosNormalizados = valores.map((valor) => String(valor).replace(/^0+/, '') || '0');
+  const { rowCount } = concluido
+    ? await db.query(`
+        UPDATE compras.pedidos_omie
+           SET "Pedido recebido" = TRUE,
+               "Pedido recebido em" = NOW(),
+               "Pedido recebido webhook" = $1,
+               updated_at = NOW()
+         WHERE n_cod_ped::text = ANY($2::text[])
+            OR regexp_replace(COALESCE(c_numero, ''), '^0+', '') = ANY($2::text[])
+      `, [messageId || topic || null, pedidosNormalizados])
+    : await db.query(`
+        WITH alvo AS (
+          SELECT n_cod_ped
+            FROM compras.pedidos_omie
+           WHERE n_cod_ped::text = ANY($2::text[])
+              OR regexp_replace(COALESCE(c_numero, ''), '^0+', '') = ANY($2::text[])
+        ),
+        status_recebido AS (
+          SELECT a.n_cod_ped,
+                 EXISTS (
+                   SELECT 1
+                     FROM logistica.recebimentos_nfe_itens i
+                     JOIN logistica.recebimentos_nfe_omie r ON r.n_id_receb = i.n_id_receb
+                    WHERE i.n_id_pedido = a.n_cod_ped
+                      AND COALESCE(r.c_cancelada, 'N') <> 'S'
+                      AND (
+                        COALESCE(r.c_recebido, 'N') = 'S'
+                        OR COALESCE(BTRIM(r.c_etapa), '') IN ('60', '80', '100')
+                      )
+                 ) AS ainda_recebido
+            FROM alvo a
+        )
+        UPDATE compras.pedidos_omie p
+           SET "Pedido recebido" = sr.ainda_recebido,
+               "Pedido recebido em" = CASE WHEN sr.ainda_recebido THEN COALESCE(p."Pedido recebido em", NOW()) ELSE NULL END,
+               "Pedido recebido webhook" = $1,
+               updated_at = NOW()
+          FROM status_recebido sr
+         WHERE p.n_cod_ped = sr.n_cod_ped
+      `, [messageId || topic || null, pedidosNormalizados]);
+
+  return { ok: true, updated: rowCount, recebido: concluido, revertido, pedidos: valores };
+}
+
 function inferNotaEntradaStatusFromSnapshot(cabec = {}, infoCadastro = {}) {
   const cancelada = String(
     infoCadastro.cCancelada
@@ -13998,6 +14118,7 @@ async function upsertRecebimentoFromWebhookPayload(rawBody = {}) {
     || cab.c_dados_adicionais
     || cab.cObsNFe
     || null;
+  const numeroPedidoWebhook = extrairNumeroPedidoCompraRecebimento(cDadosAdicionais);
 
   const fornecedorResolvido = await resolverFornecedorRecebimentoFallback({
     cChaveNfe,
@@ -14104,6 +14225,14 @@ async function upsertRecebimentoFromWebhookPayload(rawBody = {}) {
 
   const client = await pool.connect();
   try {
+    await atualizarPedidoRecebidoPorWebhookRecebimento(client, {
+      topic,
+      nIdReceb: nIdRecebValido ? nIdReceb : null,
+      numeroPedido: numeroPedidoWebhook,
+      cDadosAdicionais,
+      messageId
+    });
+
     await upsertNotaEntradaEstado(client, {
       nIdReceb: nIdRecebValido ? nIdReceb : null,
       cChaveNfe,
@@ -22049,6 +22178,13 @@ async function upsertRecebimentoNFe(recebimento, eventoWebhook = '', messageId =
       ]);
     }
 
+    await atualizarPedidoRecebidoPorWebhookRecebimento(client, {
+      topic: eventoWebhook,
+      nIdReceb,
+      cDadosAdicionais: cDadosAdicionaisFinal,
+      messageId
+    });
+
     await upsertNotaEntradaEstado(client, {
       nIdReceb,
       cChaveNfe: cChaveNfeFinal,
@@ -29731,6 +29867,66 @@ function calcularScoreAssociacaoNfePedido(itemReceb, itemPedido) {
   return score;
 }
 
+function obterAssinaturaItemRecebimentoParaAgrupar(itemReceb) {
+  const cab = itemReceb?.itensCabec || {};
+  const codigo = normalizarTextoAssociacaoNfePedido(String(
+    cab.cCodigoProduto || cab.cCodProduto || ''
+  )).replace(/\s+/g, '');
+  const descricao = normalizarTextoAssociacaoNfePedido(String(
+    cab.cDescricaoProduto || cab.cDescricao || ''
+  ));
+  return `${codigo}|${descricao}`;
+}
+
+function valoresProximosAssociacao(valorA, valorB, tolerancia = 0.01) {
+  const a = Number(valorA);
+  const b = Number(valorB);
+  return Number.isFinite(a) && Number.isFinite(b) && Math.abs(a - b) <= tolerancia;
+}
+
+function montarMapaItensPedidoReutilizaveis(itensReceb = [], itensPedido = []) {
+  const grupos = new Map();
+  itensReceb.forEach((item) => {
+    const chave = obterAssinaturaItemRecebimentoParaAgrupar(item);
+    if (!chave || chave === '|') return;
+    if (!grupos.has(chave)) {
+      grupos.set(chave, { itens: [], qtdTotal: 0, valorTotal: 0 });
+    }
+    const grupo = grupos.get(chave);
+    const cab = item?.itensCabec || {};
+    grupo.itens.push(item);
+    grupo.qtdTotal += Number(cab.nQtdeNFe || 0) || 0;
+    grupo.valorTotal += Number(cab.vTotalItem || 0) || 0;
+  });
+
+  const reutilizaveis = new Map();
+  grupos.forEach((grupo, chave) => {
+    if (grupo.itens.length < 2) return;
+
+    let melhor = null;
+    let melhorScore = -Infinity;
+    itensPedido.forEach((itemPedido) => {
+      const score = grupo.itens.reduce(
+        (acc, itemReceb) => acc + calcularScoreAssociacaoNfePedido(itemReceb, itemPedido),
+        0
+      );
+      const qtdBate = valoresProximosAssociacao(grupo.qtdTotal, itemPedido?.n_qtde, 0.0001);
+      const valorBate = valoresProximosAssociacao(grupo.valorTotal, itemPedido?.n_val_tot, 0.05);
+      const scoreFinal = score + (qtdBate ? 500 : 0) + (valorBate ? 500 : 0);
+      if (scoreFinal > melhorScore) {
+        melhorScore = scoreFinal;
+        melhor = { itemPedido, qtdBate, valorBate };
+      }
+    });
+
+    if (melhor?.itemPedido && (melhor.qtdBate || melhor.valorBate)) {
+      reutilizaveis.set(chave, melhor.itemPedido);
+    }
+  });
+
+  return reutilizaveis;
+}
+
 async function montarPlanoAssociacaoNfePedido(numeroNfe, numeroPedido, chaveNfe = null, nCodPedInformado = null) {
   const nCodPedNumerico = Number(nCodPedInformado);
   const usarIdDireto = Number.isFinite(nCodPedNumerico) && nCodPedNumerico > 0;
@@ -29791,6 +29987,7 @@ async function montarPlanoAssociacaoNfePedido(numeroNfe, numeroPedido, chaveNfe 
   });
   const mapaPorCodigoProduto = new Map();
   const mapaPorIdProduto = new Map();
+  const mapaItensPedidoReutilizaveis = montarMapaItensPedidoReutilizaveis(itensReceb, itensPedido);
 
   for (const item of itensPedido) {
     const codigo = String(item?.c_produto || '').trim();
@@ -29869,8 +30066,16 @@ async function montarPlanoAssociacaoNfePedido(numeroNfe, numeroPedido, chaveNfe 
     let itemPedidoVinculo = null;
     let criterioMatch = null;
     let scoreMatch = 0;
+    const assinaturaRecebimento = obterAssinaturaItemRecebimentoParaAgrupar(item);
+    const itemPedidoReutilizavel = mapaItensPedidoReutilizaveis.get(assinaturaRecebimento);
 
-    if (Number.isFinite(nIdProdutoRec) && nIdProdutoRec > 0 && mapaPorIdProduto.has(nIdProdutoRec)) {
+    if (itemPedidoReutilizavel) {
+      itemPedidoVinculo = itemPedidoReutilizavel;
+      criterioMatch = 'agrupamento_mesmo_item_pedido';
+      scoreMatch = Math.max(calcularScoreAssociacaoNfePedido(item, itemPedidoReutilizavel), 1500);
+    }
+
+    if (!itemPedidoVinculo && Number.isFinite(nIdProdutoRec) && nIdProdutoRec > 0 && mapaPorIdProduto.has(nIdProdutoRec)) {
       const candidatos = mapaPorIdProduto.get(nIdProdutoRec);
       const { item: melhorPorId, score } = escolherMelhorCandidatoPedido(item, candidatos);
       if (melhorPorId) {
@@ -29928,6 +30133,17 @@ async function montarPlanoAssociacaoNfePedido(numeroNfe, numeroPedido, chaveNfe 
       itensIde.nIdItPedidoExistente = nCodItem;
     }
 
+    const matchAgrupadoMesmoItem = criterioMatch === 'agrupamento_mesmo_item_pedido';
+    const pedidoQtdePreview = matchAgrupadoMesmoItem
+      ? (itensCabec?.nQtdeNFe ?? null)
+      : (itemPedidoVinculo?.n_qtde ?? null);
+    const pedidoValorPreview = matchAgrupadoMesmoItem
+      ? (itensCabec?.vTotalItem ?? null)
+      : (itemPedidoVinculo?.n_val_tot ?? null);
+    const pedidoUnidadePreview = matchAgrupadoMesmoItem
+      ? (String(itensCabec?.cUnidadeNfe || itensCabec?.cUnidadeNFe || itemPedidoVinculo?.c_unidade || '').trim() || null)
+      : (String(itemPedidoVinculo?.c_unidade || '').trim() || null);
+
     previewItens.push({
       n_sequencia: itensIde.nSequencia,
       nf_codigo_produto: codigoProdutoRec || null,
@@ -29942,9 +30158,11 @@ async function montarPlanoAssociacaoNfePedido(numeroNfe, numeroPedido, chaveNfe 
       pedido_n_cod_item: Number.isFinite(nCodItem) && nCodItem > 0 ? nCodItem : null,
       pedido_codigo_produto: String(itemPedidoVinculo?.c_produto || '').trim() || null,
       pedido_descricao_produto: String(itemPedidoVinculo?.c_descricao || '').trim() || null,
-      pedido_qtde: itemPedidoVinculo?.n_qtde ?? null,
-      pedido_unidade: String(itemPedidoVinculo?.c_unidade || '').trim() || null,
-      pedido_valor_total: itemPedidoVinculo?.n_val_tot ?? null,
+      pedido_qtde: pedidoQtdePreview,
+      pedido_unidade: pedidoUnidadePreview,
+      pedido_valor_total: pedidoValorPreview,
+      pedido_qtde_original: itemPedidoVinculo?.n_qtde ?? null,
+      pedido_valor_total_original: itemPedidoVinculo?.n_val_tot ?? null,
       criterio_match: criterioMatch,
       score_match: scoreMatch
     });
@@ -30143,6 +30361,51 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
       if (seq > 0) overrideMap.set(seq, ov);
     }
 
+    const overridesValorPedido = [];
+    for (const itemPreview of (Array.isArray(plano?.itens_preview) ? plano.itens_preview : [])) {
+      const seq = Number(itemPreview?.n_sequencia || 0);
+      const override = overrideMap.get(seq);
+      const valorTotalNovo = parseValorDecimalNfe(override?.nValTot);
+      if (!seq || !Number.isFinite(valorTotalNovo) || valorTotalNovo < 0) continue;
+
+      const nCodItem = Number(override?.nIdItPedidoExistente || itemPreview?.pedido_n_cod_item || 0);
+      if (!Number.isFinite(nCodItem) || nCodItem <= 0) continue;
+
+      const qtdBase = parseValorDecimalNfe(override?.nQtde ?? itemPreview?.pedido_qtde);
+      const valorUnitNovo = Number.isFinite(qtdBase) && qtdBase > 0
+        ? Number((valorTotalNovo / qtdBase).toFixed(6))
+        : null;
+
+      overridesValorPedido.push({ nCodItem, valorTotalNovo, valorUnitNovo });
+      itemPreview.pedido_valor_total = valorTotalNovo;
+    }
+
+    if (overridesValorPedido.length > 0) {
+      for (const ovValor of overridesValorPedido) {
+        await pool.query(
+          `UPDATE compras.pedidos_omie_produtos
+              SET n_val_tot = $1,
+                  n_val_unit = COALESCE($2, n_val_unit),
+                  updated_at = NOW()
+            WHERE n_cod_ped = $3
+              AND n_cod_item = $4`,
+          [ovValor.valorTotalNovo, ovValor.valorUnitNovo, plano.n_cod_ped, ovValor.nCodItem]
+        );
+      }
+
+      await pool.query(
+        `UPDATE compras.pedidos_omie p
+            SET n_valor = COALESCE((
+                  SELECT SUM(COALESCE(pp.n_val_tot, 0))
+                    FROM compras.pedidos_omie_produtos pp
+                   WHERE pp.n_cod_ped = p.n_cod_ped
+                ), 0),
+                updated_at = NOW()
+          WHERE p.n_cod_ped = $1`,
+        [plano.n_cod_ped]
+      );
+    }
+
     // Valida que todos os itens da NF-e foram mapeados a um item do pedido Omie
     // (considerando possíveis ajustes manuais vindos do frontend)
     const itensSemMapeamento = Array.isArray(plano?.itens_preview)
@@ -30316,6 +30579,8 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
         // Mapa de unidade/quantidade por nCodItem do pedido
         const unidadePorCodItem = {};
         const quantidadePorCodItem = {};
+        const quantidadeRecebidaPorSeq = {};
+        const unidadeRecebidaPorSeq = {};
         (pedidoConsulta?.produtos_consulta || []).forEach(p => {
           if (p.nCodItem) {
             unidadePorCodItem[String(p.nCodItem)] = p.cUnidade;
@@ -30331,6 +30596,13 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
           }
           if (!Number.isFinite(quantidadePorCodItem[chaveItem]) && Number.isFinite(Number(itemPreview?.pedido_qtde))) {
             quantidadePorCodItem[chaveItem] = Number(itemPreview.pedido_qtde);
+          }
+          if (itemPreview?.criterio_match === 'agrupamento_mesmo_item_pedido') {
+            const seqPreview = Number(itemPreview?.n_sequencia || 0);
+            if (seqPreview) {
+              quantidadeRecebidaPorSeq[String(seqPreview)] = Number(itemPreview?.nf_qtde ?? itemPreview?.pedido_qtde);
+              unidadeRecebidaPorSeq[String(seqPreview)] = itemPreview?.nf_unidade || itemPreview?.pedido_unidade || unidadePorCodItem[chaveItem] || null;
+            }
           }
         });
 
@@ -30455,14 +30727,18 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
           const cfopServicoEntrada = previewItem?.item_servico ? previewItem?.servico_cfop_entrada : null;
           const cUnidadePedido = nIdItPed ? unidadePorCodItem[String(nIdItPed)] : null;
           const nQtdePedido = nIdItPed ? quantidadePorCodItem[String(nIdItPed)] : null;
+          const nQtdeAgrupada = Number(quantidadeRecebidaPorSeq[String(nSeq)]);
+          const cUnidadeAgrupada = unidadeRecebidaPorSeq[String(nSeq)] || null;
 
           // Override do user tem prioridade sobre o valor do pedido
           const override = overrideMap.get(nSeq);
-          const cUnidadeFinal = override?.cUnidade || cUnidadePedido || null;
+          const cUnidadeFinal = override?.cUnidade || cUnidadeAgrupada || cUnidadePedido || null;
           const nQtdeOverride = Number(override?.nQtde);
           const nQtdeRecebidaFinal = Number.isFinite(nQtdeOverride) && nQtdeOverride > 0
             ? nQtdeOverride
-            : (Number.isFinite(nQtdePedido) && nQtdePedido > 0 ? nQtdePedido : null);
+            : (Number.isFinite(nQtdeAgrupada) && nQtdeAgrupada > 0
+              ? nQtdeAgrupada
+              : (Number.isFinite(nQtdePedido) && nQtdePedido > 0 ? nQtdePedido : null));
 
           const ajustes = {
             codigo_local_estoque: RECEBIMENTO_NFE_LOCAL_ESTOQUE_PADRAO


### PR DESCRIPTION
## O que mudou
- Menu Recebimentos abre direto o modal Localizar NF-e.
- Modal Localizar NF-e fecha somente pelo X.
- NF-e recebida/concluida fica em modo consulta, com aviso destacado e sem pedidos sugeridos.
- Corrige loading visual do botao Associar e adiciona acao para buscar outra NF-e apos associar.
- Permite editar valor do item do pedido quando houver divergencia.
- Permite agrupar multiplas linhas da NF-e no mesmo item do pedido quando a soma bate.
- Marca pedido como recebido via webhook RecebimentoProduto.Concluido e remove marca em Revertido quando aplicavel.

## Por que
Evitar confusao operacional no recebimento e tratar corretamente notas divididas em mais de uma linha para o mesmo item do pedido.

## Como validar
- Abrir Recebimentos pelo menu lateral e confirmar abertura do modal Localizar NF-e.
- Buscar NF-e recebida/concluida e confirmar modo consulta sem pedidos sugeridos.
- Pre-visualizar NF-e 000061572 com pedido 2588 e confirmar agrupamento sem divergencias falsas.
- Associar uma NF-e e confirmar que o botao nao fica preso em loading e permite buscar outra NF-e.

## Arquivos alterados
- colaborador-fluxo-branch-seguro.instructions.md
- menu_produto.html
- menu_produto.js
- server.js