### PR TITLE
fix(recebimento): tratar item informativo na associacao nfe

### DIFF
--- a/menu_produto.html
+++ b/menu_produto.html
@@ -9327,7 +9327,7 @@
   <!-- Interceptor de sessão: precisa carregar ANTES de qualquer módulo que faça fetch -->
   <script src="/public/js/sessao_resiliente.js?v=20260422a"></script>
   <script type="module" src="login/login.js"></script>
-  <script type="module" src="menu_produto.js?v=20260513b"></script>
+  <script type="module" src="menu_produto.js?v=20260515a"></script>
   
   <script type="module" src="./requisicoes_omie/filtro_produto.js"></script>
   <script type="module" src="./requisicoes_omie/ListarProdutos.js"></script>

--- a/menu_produto.js
+++ b/menu_produto.js
@@ -48741,6 +48741,9 @@ function renderPreviewAssociacaoPedidoNfe(preview) {
   const itens = [...window.__associarNfePreviewEstadoItens].sort(
     (a, b) => Number(a?.n_sequencia || 0) - Number(b?.n_sequencia || 0)
   );
+  const itensInformativosPedido = Array.isArray(preview?.itens_pedido_informativos)
+    ? preview.itens_pedido_informativos
+    : [];
 
   if (!window.__associarNfeCamposEditados || typeof window.__associarNfeCamposEditados !== 'object') {
     window.__associarNfeCamposEditados = {};
@@ -48776,6 +48779,7 @@ function renderPreviewAssociacaoPedidoNfe(preview) {
     return compararQuantidadePreview(item) || compararUnidadePreview(item, unidadePedido);
   }).length;
   const gruposMesmoItem = itens.filter((item) => item?.criterio_match === 'agrupamento_mesmo_item_pedido').length;
+  const itensInformativosTotal = itensInformativosPedido.length;
 
   const totalValorNfPreview = itens.reduce((acc, item) => acc + (Number(item?.nf_valor_total || 0) || 0), 0);
   const totalValorPedidoPreview = itens.reduce((acc, item) => {
@@ -48810,6 +48814,10 @@ function renderPreviewAssociacaoPedidoNfe(preview) {
       <div style="background:${divergenciasQtdUnid > 0 ? '#fef2f2' : '#eff6ff'};border:1px solid ${divergenciasQtdUnid > 0 ? '#fecaca' : '#bfdbfe'};border-radius:10px;padding:10px;">
         <div style="font-size:11px;color:${divergenciasQtdUnid > 0 ? '#991b1b' : '#1d4ed8'};">Qtd/Unid. divergentes</div>
         <div style="font-size:13px;font-weight:700;color:${divergenciasQtdUnid > 0 ? '#991b1b' : '#1d4ed8'};">${divergenciasQtdUnid}</div>
+      </div>
+      <div style="background:${itensInformativosTotal > 0 ? '#fff7ed' : '#f8fafc'};border:1px solid ${itensInformativosTotal > 0 ? '#fed7aa' : '#e2e8f0'};border-radius:10px;padding:10px;">
+        <div style="font-size:11px;color:${itensInformativosTotal > 0 ? '#9a3412' : '#64748b'};">Itens informativos</div>
+        <div style="font-size:13px;font-weight:700;color:${itensInformativosTotal > 0 ? '#9a3412' : '#0f172a'};">${itensInformativosTotal}</div>
       </div>
     </div>
   `;
@@ -48900,8 +48908,31 @@ function renderPreviewAssociacaoPedidoNfe(preview) {
       }).join('')
     : '<tr><td colspan="12" style="padding:10px;font-size:11px;color:#64748b;text-align:center;">Sem itens para pré-visualização.</td></tr>';
 
+  const itensInformativosHtml = itensInformativosPedido.length
+    ? `
+      <div style="margin:0 0 10px;padding:10px 12px;border:1px solid #fed7aa;background:#fff7ed;color:#9a3412;border-radius:8px;font-size:12px;">
+        <div style="display:flex;align-items:center;gap:8px;font-weight:800;margin-bottom:8px;">
+          <i class="fa-solid fa-circle-info"></i>
+          <span>${itensInformativosPedido.length} item(ns) do pedido foram tratados como informativos</span>
+        </div>
+        <div style="font-size:11px;line-height:1.45;margin-bottom:8px;">Eles existem no pedido apenas como referencia interna e nao serao associados a NF-e. A associacao segue somente com os itens que vieram na nota.</div>
+        <div style="display:grid;gap:6px;">
+          ${itensInformativosPedido.map((itemInfo) => `
+            <div style="display:grid;grid-template-columns:minmax(90px,.7fr) minmax(220px,2fr) minmax(80px,.5fr) minmax(90px,.7fr);gap:8px;align-items:center;background:#ffffff;border:1px solid #fed7aa;border-radius:8px;padding:8px;">
+              <div style="font-weight:800;color:#7c2d12;font-size:11px;">${escapeHtml(String(itemInfo?.pedido_codigo_produto || '-'))}</div>
+              <div style="color:#431407;font-size:11px;line-height:1.35;">${escapeHtml(String(itemInfo?.pedido_descricao_produto || '-'))}</div>
+              <div style="text-align:right;color:#7c2d12;font-size:11px;">${escapeHtml(String(itemInfo?.pedido_qtde ?? '-'))} ${escapeHtml(String(itemInfo?.pedido_unidade || ''))}</div>
+              <div style="text-align:right;font-weight:800;color:#7c2d12;font-size:11px;">${escapeHtml(formatarValorRecebimento(itemInfo?.pedido_valor_total))}</div>
+            </div>
+          `).join('')}
+        </div>
+      </div>
+    `
+    : '';
+
   previewConteudo.innerHTML = `
     ${resumoHtml}
+    ${itensInformativosHtml}
     ${gruposMesmoItem > 0 ? `<div style="margin:0 0 10px;padding:10px 12px;border:1px solid #bbf7d0;background:#ecfdf5;color:#166534;border-radius:8px;font-size:12px;font-weight:700;"><i class="fa-solid fa-layer-group" style="margin-right:6px;"></i>${gruposMesmoItem} linha(s) da NF-e foram agrupadas no mesmo item do pedido. A conferência usa a soma das linhas, não cada linha isolada.</div>` : ''}
     <div style="margin:0 0 10px;padding:9px 12px;border:1px solid #bae6fd;background:#f0f9ff;color:#0c4a6e;border-radius:8px;font-size:12px;font-weight:700;">Arraste o bloco do item do Pedido (coluna azul com ícone <i class="fa-solid fa-grip-vertical"></i>) para outra linha da NF-e para trocar a associação.</div>
     ${(divergenciasValor > 0 || divergenciasQtdUnid > 0) ? `<div style="margin:0 0 10px;padding:10px 12px;border:1px solid #fecaca;background:#fff1f2;color:#b91c1c;border-radius:8px;font-size:12px;font-weight:700;">Existem divergências de valor, quantidade ou unidade entre a NF-e e o pedido.${divergenciasQtdUnid > 0 ? ' Edite os campos de Qtd/Unid. do Pedido (em vermelho) antes de associar.' : ' Os campos divergentes estão destacados em vermelho.'}</div>` : ''}

--- a/server.js
+++ b/server.js
@@ -31177,7 +31177,7 @@ async function montarPlanoAssociacaoNfePedido(numeroNfe, numeroPedido, chaveNfe 
     }
 
     const nCodItem = Number(itemPedidoVinculo?.n_cod_item);
-    if (Number.isFinite(nCodItem) && nCodItem > 0) {
+    if (!servicoCfop.servico && Number.isFinite(nCodItem) && nCodItem > 0) {
       itensIde.nIdItPedidoExistente = nCodItem;
     }
 
@@ -31218,6 +31218,19 @@ async function montarPlanoAssociacaoNfePedido(numeroNfe, numeroPedido, chaveNfe 
     return { itensIde };
   });
 
+  const itensPedidoInformativos = itensPedido
+    .filter(itemPedidoDisponivel)
+    .map((itemPedido) => ({
+      pedido_n_cod_item: Number(itemPedido?.n_cod_item || 0) || null,
+      pedido_codigo_produto: String(itemPedido?.c_produto || '').trim() || null,
+      pedido_descricao_produto: String(itemPedido?.c_descricao || '').trim() || null,
+      pedido_qtde: itemPedido?.n_qtde ?? null,
+      pedido_unidade: String(itemPedido?.c_unidade || '').trim() || null,
+      pedido_valor_total: itemPedido?.n_val_tot ?? null,
+      item_informativo_sugerido: true,
+      motivo: 'Item do pedido sem linha correspondente na NF-e'
+    }));
+
   return {
     numero_nfe: String(recebimento?.cabec?.cNumeroNFe || '').trim() || String(numeroNfe || '').trim(),
     n_id_receb: Number(recebimento?.cabec?.nIdReceb || 0) || null,
@@ -31229,6 +31242,7 @@ async function montarPlanoAssociacaoNfePedido(numeroNfe, numeroPedido, chaveNfe 
     itens_sem_match_total: previewItens.filter(item => !item.pedido_item_encontrado).length,
     recebimento_omie: recebimento,
     itens_preview: previewItens,
+    itens_pedido_informativos: itensPedidoInformativos,
     itensRecebimentoEditar
   };
 }
@@ -31531,6 +31545,15 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
       if (Number.isFinite(idProdutoServico) && idProdutoServico > 0) {
         itemEditar.itensIde.cAcao = 'ASSOCIAR-PRODUTO';
         itemEditar.itensIde.nIdProdutoExistente = idProdutoServico;
+      }
+    });
+
+    itensParaEnviar.forEach((itemEditar) => {
+      const itensIde = itemEditar?.itensIde || {};
+      const acao = String(itensIde?.cAcao || '').trim().toUpperCase();
+      if (acao !== 'ASSOCIAR-PEDIDO') {
+        delete itensIde.nIdPedidoExistente;
+        delete itensIde.nIdItPedidoExistente;
       }
     });
 


### PR DESCRIPTION
## O que mudou
- Corrige payload enviado para Omie removendo tags de pedido quando a acao nao e ASSOCIAR-PEDIDO.
- Evita que itens de servico carreguem nIdItPedidoExistente indevidamente.
- Mostra itens extras do pedido como itens informativos na previa da associacao NF-e x Pedido.
- Atualiza cache buster do menu_produto.js.

## Por que
Pedidos podem conter item extra apenas como referencia interna da peca comprada. Esse item nao vem na NF-e e nao deve bloquear a associacao nem gerar payload invalido para a Omie.

## Como validar
- Abrir Localizar NF-e.
- Previsualizar NF 445759 com pedido 2675.
- Confirmar que o item extra aparece como informativo.
- Associar e confirmar que nao ocorre erro de nIdItPedidoExistente com cAcao diferente de ASSOCIAR-PEDIDO.

## Arquivos alterados
- menu_produto.html
- menu_produto.js
- server.js