### PR TITLE
fix(recebimento): restaurar normalizarCfopServicoRecebimento removida no merge

### DIFF
--- a/server.js
+++ b/server.js
@@ -30765,6 +30765,13 @@ function calcularScoreAssociacaoNfePedido(itemReceb, itemPedido) {
   return score;
 }
 
+function normalizarCfopServicoRecebimento(valor) {
+  const cfop = String(valor || '').replace(/\D/g, '');
+  if (cfop === '5933') return { servico: true, cfopEntrada: '1.933' };
+  if (cfop === '6933') return { servico: true, cfopEntrada: '2.933' };
+  return { servico: false, cfopEntrada: null };
+}
+
 async function montarPlanoAssociacaoNfePedido(numeroNfe, numeroPedido, chaveNfe = null, nCodPedInformado = null) {
   const nCodPedNumerico = Number(nCodPedInformado);
   const usarIdDireto = Number.isFinite(nCodPedNumerico) && nCodPedNumerico > 0;
@@ -30938,6 +30945,16 @@ async function montarPlanoAssociacaoNfePedido(numeroNfe, numeroPedido, chaveNfe 
       }
     }
 
+    const cfopNf = String(
+      itensCabec?.cCFOP
+      || itensCabec?.cCfop
+      || itensInfoAdic?.cCFOP
+      || itensInfoAdic?.cCfop
+      || itensInfoAdic?.cCFOPEntrada
+      || itensInfoAdic?.cCfopEntrada
+    ).trim();
+    const servicoCfop = normalizarCfopServicoRecebimento(cfopNf);
+
     const itensIde = {
       nSequencia: Number.isFinite(nSequencia) && nSequencia > 0 ? nSequencia : (idx + 1),
       cAcao: servicoCfop.servico ? 'ASSOCIAR-PRODUTO' : 'ASSOCIAR-PEDIDO'
@@ -30959,7 +30976,10 @@ async function montarPlanoAssociacaoNfePedido(numeroNfe, numeroPedido, chaveNfe 
       nf_qtde: itensCabec?.nQtdeNFe ?? null,
       nf_unidade: String(itensCabec?.cUnidadeNfe || '').trim() || null,
       nf_valor_total: itensCabec?.vTotalItem ?? null,
-      pedido_item_encontrado: !!itemPedidoVinculo,
+      nf_cfop: cfopNf || null,
+      item_servico: servicoCfop.servico,
+      servico_cfop_entrada: servicoCfop.cfopEntrada,
+      pedido_item_encontrado: !!itemPedidoVinculo || servicoCfop.servico,
       pedido_n_cod_item: Number.isFinite(nCodItem) && nCodItem > 0 ? nCodItem : null,
       pedido_codigo_produto: String(itemPedidoVinculo?.c_produto || '').trim() || null,
       pedido_descricao_produto: String(itemPedidoVinculo?.c_descricao || '').trim() || null,
@@ -31492,7 +31512,9 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
           const ajustes = {};
           if (aplicarEstoqueEspecial) ajustes.codigo_local_estoque = ESTOQUE_LOCAL_ESPECIAL;
           if (cUnidadeFinal) ajustes.cUnidade = cUnidadeFinal;
-          if (cfopCalculado) ajustes.cCFOPEntrada = cfopCalculado;
+          const previewItem = (plano?.itens_preview || []).find(p => p.n_sequencia === nSeq);
+          const cfopServicoEntrada = previewItem?.item_servico ? previewItem?.servico_cfop_entrada : null;
+          if (cfopServicoEntrada || cfopCalculado) ajustes.cCFOPEntrada = cfopServicoEntrada || cfopCalculado;
           // Nota: nQtde não é campo válido em itensAjustes da Omie
 
           // Só incluir o item se tiver ajustes


### PR DESCRIPTION
## Problema

A funcao \
ormalizarCfopServicoRecebimento\ e as variaveis derivadas (\cfopNf\, \servicoCfop\) foram removidas acidentalmente durante o merge de \origin/main\ no PR #45 (\eat/recebimento-vincular-servico-produto\).

Isso causava \ReferenceError: servicoCfop is not defined\ ao tentar pre-visualizar ou associar qualquer NF-e a um pedido.

## O que foi corrigido em \server.js\

- Restaurada a funcao \
ormalizarCfopServicoRecebimento\ (detecta CFOP 5933/6933 de servico)
- Restaurada declaracao de \cfopNf\ e \servicoCfop\ no map de \montarPlanoAssociacaoNfePedido\
- Restaurados campos \
f_cfop\, \item_servico\, \servico_cfop_entrada\ no \previewItens.push\
- Corrigido \pedido_item_encontrado\ para incluir itens de servico (\|| servicoCfop.servico\)
- Restaurado \cfopServicoEntrada\ no step de edicao de itens (prioridade sobre \cfopCalculado\)

## Como validar

1. Abrir o modal **Associar NF-e a Pedido**
2. Informar numero de NF-e e numero do pedido
3. Clicar em **Pre-visualizar** — deve funcionar sem erro
4. Clicar em **Associar** — deve associar normalmente