### PR TITLE
feat(recebimento): matching sorted-greedy NF-e x pedido

### DIFF
--- a/menu_produto.js
+++ b/menu_produto.js
@@ -51451,17 +51451,12 @@ function snapshotEdicoesQtdUnidAssociacaoNfe() {
     window.__associarNfeCamposEditados = {};
   }
 
-  previewConteudo.querySelectorAll('.assoc-override-qtd, .assoc-override-unid, .assoc-override-valor').forEach((input) => {
+  previewConteudo.querySelectorAll('.assoc-override-unid, .assoc-override-valor').forEach((input) => {
     const seq = Number(input.dataset.seq || 0);
     if (!seq) return;
 
     if (!window.__associarNfeCamposEditados[seq]) {
       window.__associarNfeCamposEditados[seq] = {};
-    }
-
-    if (input.classList.contains('assoc-override-qtd')) {
-      const valorQtd = parseFloat(String(input.value || '').replace(',', '.'));
-      window.__associarNfeCamposEditados[seq].nQtde = Number.isFinite(valorQtd) ? valorQtd : null;
     }
 
     if (input.classList.contains('assoc-override-unid')) {
@@ -51751,9 +51746,7 @@ function renderPreviewAssociacaoPedidoNfe(preview) {
               </div>`}
             </td>
             <td style="padding:7px 8px;font-size:11px;color:${corQtd};background:${bgQtd};text-align:right;white-space:nowrap;">${
-              (!isServico && (divergiuQtd || divergiuUnidade))
-                ? `<input type="text" class="assoc-override-qtd" data-seq="${seq}" value="${escapeHtml(String(qtdPedido))}" style="width:60px;padding:2px 4px;font-size:11px;font-weight:700;color:#b91c1c;border:1px solid #fca5a5;border-radius:4px;text-align:right;background:#fff5f5;" title="Edite a quantidade para associação">`
-                : escapeHtml(String(qtdPedido))
+              escapeHtml(String(qtdPedido))
             }</td>
             <td style="padding:7px 8px;font-size:11px;color:${corUnid};background:${bgUnid};text-align:center;white-space:nowrap;">${
               (!isServico && (divergiuQtd || divergiuUnidade))
@@ -51832,7 +51825,7 @@ function renderPreviewAssociacaoPedidoNfe(preview) {
 
   previewWrap.style.display = 'block';
   habilitarDragDropAssociacaoPedidoNfe(preview);
-  previewConteudo.querySelectorAll('.assoc-override-qtd, .assoc-override-unid, .assoc-override-valor').forEach((input) => {
+  previewConteudo.querySelectorAll('.assoc-override-unid, .assoc-override-valor').forEach((input) => {
     input.addEventListener('input', snapshotEdicoesQtdUnidAssociacaoNfe);
     input.addEventListener('change', snapshotEdicoesQtdUnidAssociacaoNfe);
   });
@@ -52363,16 +52356,13 @@ async function confirmarAssociacaoPedidoNfeOmie() {
 
     const previewConteudo = document.getElementById('modalAssociarPedidoNfePreviewConteudo');
     if (previewConteudo) {
-      previewConteudo.querySelectorAll('.assoc-override-qtd, .assoc-override-unid, .assoc-override-valor').forEach(input => {
+      previewConteudo.querySelectorAll('.assoc-override-unid, .assoc-override-valor').forEach(input => {
         const seq = Number(input.dataset.seq || 0);
         if (!seq) return;
         let entry = itensOverrideMap.get(seq);
         if (!entry) {
           entry = { n_sequencia: seq };
           itensOverrideMap.set(seq, entry);
-        }
-        if (input.classList.contains('assoc-override-qtd')) {
-          entry.nQtde = parseFloat(String(input.value || '').replace(',', '.')) || null;
         }
         if (input.classList.contains('assoc-override-unid')) {
           entry.cUnidade = String(input.value || '').trim().toUpperCase() || null;

--- a/server.js
+++ b/server.js
@@ -31623,11 +31623,15 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
           const isServico = !!(previewItem?.item_servico);
           const cfopServicoEntrada = isServico ? previewItem?.servico_cfop_entrada : null;
 
+          const nQtdeOverride = Number(override?.nQtde || 0);
+
           const ajustes = {};
           if (!isServico) ajustes.codigo_local_estoque = Number(ALMOX_LOCAL_PADRAO);
           if (cUnidadeFinal) ajustes.cUnidade = cUnidadeFinal;
           if (cfopServicoEntrada || cfopCalculado) ajustes.cCFOPEntrada = cfopServicoEntrada || cfopCalculado;
-          // Nota: nQtde não é campo válido em itensAjustes da Omie
+          // nQtde: inclui o valor digitado pelo user (medição física pode diferir da conversão Omie).
+          // Se a Omie rejeitar o campo, o Passo 3 faz retry sem ele (ver abaixo).
+          if (!isServico && Number.isFinite(nQtdeOverride) && nQtdeOverride > 0) ajustes.nQtde = nQtdeOverride;
 
           // Só incluir o item se tiver ajustes
           if (Object.keys(ajustes).length === 0) return null;
@@ -31698,57 +31702,43 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
       }
     }
 
-    // ─── Passo 3: EDITAR itens com cUnidade + nQtde (+ codigo_local_estoque se especial) ───
+    // ─── Passo 3: EDITAR itens com codigo_local_estoque + cUnidade + nQtde (se override) ───
+    // nQtde é enviado junto para evitar que um EDITAR separado sem os outros campos reverta
+    // o armazém/unidade. Se a Omie rejeitar o payload com nQtde, faz retry sem ele.
     if (itensEditarEstoque && itensEditarEstoque.length > 0) {
+      const hasQtdeOverride = itensEditarEstoque.some(it => it.itensAjustes?.nQtde != null);
       try {
         const payloadEstoque = {
           ide: { nIdReceb: Number(plano.n_id_receb) },
           itensRecebimentoEditar: itensEditarEstoque
         };
-        console.log('[Compras/NFeAssociarPedido] ===== PASSO 3: estoque =====');
+        console.log('[Compras/NFeAssociarPedido] ===== PASSO 3: estoque' + (hasQtdeOverride ? ' + nQtde' : '') + ' =====');
         console.log(JSON.stringify(payloadEstoque, null, 2));
         console.log('[Compras/NFeAssociarPedido] ===================================');
         await chamarApiRecebimentoNfeOmieComRetryRedundant('AlterarRecebimento', payloadEstoque, {
           tentativasMaximas: 2
         });
-        console.log('[Compras/NFeAssociarPedido] Local estoque/unidade atualizados com sucesso.');
+        console.log('[Compras/NFeAssociarPedido] Local estoque/unidade' + (hasQtdeOverride ? '/nQtde' : '') + ' atualizados com sucesso.');
       } catch (errEstoque) {
-        console.warn('[Compras/NFeAssociarPedido] Falha ao atualizar local estoque:', errEstoque?.message);
-      }
-    }
-
-    // ─── Passo 3b: nQtde override (quando usuário informou qty diferente da conversão Omie) ───
-    // Omie calcula qty convertida via fator interno do produto (ex: KG→MTS). Se o usuário
-    // forneceu uma medição física diferente (campo assoc-override-qtd na prévia), tentamos
-    // sobrescrever com EDITAR separado. Executa depois do Passo 3 para não arriscar o armazém/unidade.
-    const itensEditarQtde = (plano?.itensRecebimentoEditar || []).map(itemEditar => {
-      const nSeq = itemEditar.itensIde?.nSequencia;
-      const override = overrideMap.get(nSeq);
-      const nQtdeOverride = Number(override?.nQtde || 0);
-      if (!Number.isFinite(nQtdeOverride) || nQtdeOverride <= 0) return null;
-      const previewItem = (plano?.itens_preview || []).find(p => p.n_sequencia === nSeq);
-      if (!!(previewItem?.item_servico)) return null;
-      return {
-        itensIde: { nSequencia: nSeq, cAcao: 'EDITAR' },
-        itensAjustes: { nQtde: nQtdeOverride }
-      };
-    }).filter(Boolean);
-
-    if (itensEditarQtde.length > 0) {
-      try {
-        const payloadQtde = {
-          ide: { nIdReceb: Number(plano.n_id_receb) },
-          itensRecebimentoEditar: itensEditarQtde
-        };
-        console.log('[Compras/NFeAssociarPedido] ===== PASSO 3b: nQtde override =====');
-        console.log(JSON.stringify(payloadQtde, null, 2));
-        console.log('[Compras/NFeAssociarPedido] ===================================');
-        await chamarApiRecebimentoNfeOmieComRetryRedundant('AlterarRecebimento', payloadQtde, {
-          tentativasMaximas: 1
-        });
-        console.log('[Compras/NFeAssociarPedido] nQtde override aplicado com sucesso.');
-      } catch (errQtde) {
-        console.warn('[Compras/NFeAssociarPedido] nQtde override ignorado (Omie pode não suportar o campo):', errQtde?.message);
+        if (hasQtdeOverride) {
+          // Retry sem nQtde: garante que armazém e unidade sejam aplicados mesmo se Omie rejeitar nQtde
+          console.warn('[Compras/NFeAssociarPedido] Passo 3 com nQtde falhou, retrying sem nQtde:', errEstoque?.message);
+          const itensSemQtde = itensEditarEstoque.map(it => ({
+            ...it,
+            itensAjustes: Object.fromEntries(Object.entries(it.itensAjustes).filter(([k]) => k !== 'nQtde'))
+          }));
+          try {
+            await chamarApiRecebimentoNfeOmieComRetryRedundant('AlterarRecebimento', {
+              ide: { nIdReceb: Number(plano.n_id_receb) },
+              itensRecebimentoEditar: itensSemQtde
+            }, { tentativasMaximas: 2 });
+            console.log('[Compras/NFeAssociarPedido] Passo 3 (sem nQtde) aplicado com sucesso.');
+          } catch (errFallback) {
+            console.warn('[Compras/NFeAssociarPedido] Falha ao atualizar local estoque:', errFallback?.message);
+          }
+        } else {
+          console.warn('[Compras/NFeAssociarPedido] Falha ao atualizar local estoque:', errEstoque?.message);
+        }
       }
     }
 

--- a/server.js
+++ b/server.js
@@ -31609,7 +31609,7 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
         }
 
         // --- EDITAR cada item: cUnidade + nQtde (do pedido ou override do user) ---
-        // Se conta especial, também aplica codigo_local_estoque
+        // Sempre aplica codigo_local_estoque = ALMOX_LOCAL_PADRAO para itens físicos (não-serviço)
         itensEditarEstoque = plano.itensRecebimentoEditar.map(itemEditar => {
           const nSeq = itemEditar.itensIde?.nSequencia;
           const nIdItPed = itemEditar.itensIde?.nIdItPedidoExistente;
@@ -31619,11 +31619,13 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
           const override = overrideMap.get(nSeq);
           const cUnidadeFinal = override?.cUnidade || cUnidadePedido || null;
 
-          const ajustes = {};
-          if (aplicarEstoqueEspecial) ajustes.codigo_local_estoque = ESTOQUE_LOCAL_ESPECIAL;
-          if (cUnidadeFinal) ajustes.cUnidade = cUnidadeFinal;
           const previewItem = (plano?.itens_preview || []).find(p => p.n_sequencia === nSeq);
-          const cfopServicoEntrada = previewItem?.item_servico ? previewItem?.servico_cfop_entrada : null;
+          const isServico = !!(previewItem?.item_servico);
+          const cfopServicoEntrada = isServico ? previewItem?.servico_cfop_entrada : null;
+
+          const ajustes = {};
+          if (!isServico) ajustes.codigo_local_estoque = Number(ALMOX_LOCAL_PADRAO);
+          if (cUnidadeFinal) ajustes.cUnidade = cUnidadeFinal;
           if (cfopServicoEntrada || cfopCalculado) ajustes.cCFOPEntrada = cfopServicoEntrada || cfopCalculado;
           // Nota: nQtde não é campo válido em itensAjustes da Omie
 

--- a/server.js
+++ b/server.js
@@ -31709,7 +31709,7 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
     // nQtde é enviado junto para evitar que um EDITAR separado sem os outros campos reverta
     // o armazém/unidade. Se a Omie rejeitar o payload com nQtde, faz retry sem ele.
     if (itensEditarEstoque && itensEditarEstoque.length > 0) {
-      const hasQtdeOverride = itensEditarEstoque.some(it => it.itensAjustes?.nQtde != null);
+      const hasQtdeOverride = itensEditarEstoque.some(it => it.nQtde != null);
       try {
         const payloadEstoque = {
           ide: { nIdReceb: Number(plano.n_id_receb) },

--- a/server.js
+++ b/server.js
@@ -31717,6 +31717,41 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
       }
     }
 
+    // ─── Passo 3b: nQtde override (quando usuário informou qty diferente da conversão Omie) ───
+    // Omie calcula qty convertida via fator interno do produto (ex: KG→MTS). Se o usuário
+    // forneceu uma medição física diferente (campo assoc-override-qtd na prévia), tentamos
+    // sobrescrever com EDITAR separado. Executa depois do Passo 3 para não arriscar o armazém/unidade.
+    const itensEditarQtde = (plano?.itensRecebimentoEditar || []).map(itemEditar => {
+      const nSeq = itemEditar.itensIde?.nSequencia;
+      const override = overrideMap.get(nSeq);
+      const nQtdeOverride = Number(override?.nQtde || 0);
+      if (!Number.isFinite(nQtdeOverride) || nQtdeOverride <= 0) return null;
+      const previewItem = (plano?.itens_preview || []).find(p => p.n_sequencia === nSeq);
+      if (!!(previewItem?.item_servico)) return null;
+      return {
+        itensIde: { nSequencia: nSeq, cAcao: 'EDITAR' },
+        itensAjustes: { nQtde: nQtdeOverride }
+      };
+    }).filter(Boolean);
+
+    if (itensEditarQtde.length > 0) {
+      try {
+        const payloadQtde = {
+          ide: { nIdReceb: Number(plano.n_id_receb) },
+          itensRecebimentoEditar: itensEditarQtde
+        };
+        console.log('[Compras/NFeAssociarPedido] ===== PASSO 3b: nQtde override =====');
+        console.log(JSON.stringify(payloadQtde, null, 2));
+        console.log('[Compras/NFeAssociarPedido] ===================================');
+        await chamarApiRecebimentoNfeOmieComRetryRedundant('AlterarRecebimento', payloadQtde, {
+          tentativasMaximas: 1
+        });
+        console.log('[Compras/NFeAssociarPedido] nQtde override aplicado com sucesso.');
+      } catch (errQtde) {
+        console.warn('[Compras/NFeAssociarPedido] nQtde override ignorado (Omie pode não suportar o campo):', errQtde?.message);
+      }
+    }
+
     // ─── Passo 4: Concluir recebimento (etapa 60) ───
     // ConcluirRecebimento é mais confiável que AlterarEtapaRecebimento
     // (AlterarEtapaRecebimento pode retornar "OK" sem efetivamente mudar a etapa)

--- a/server.js
+++ b/server.js
@@ -31412,8 +31412,9 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
     if (nCodCC) {
       try {
         // Busca dados atuais do recebimento + unidades do pedido
+        // Usa ComRetryRedundant para tolerar erros REDUNDANT da Omie (chamadas anteriores na mesma sessão)
         const [recebAtual, pedidoConsulta] = await Promise.all([
-          chamarApiRecebimentoNfeOmie('ConsultarRecebimento', { nIdReceb: Number(plano.n_id_receb) }),
+          chamarApiRecebimentoNfeOmieComRetryRedundant('ConsultarRecebimento', { nIdReceb: Number(plano.n_id_receb) }, { tentativasMaximas: 3, margemSegundos: 8 }),
           fetch('https://app.omie.com.br/api/v1/produtos/pedidocompra/', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -31629,17 +31630,19 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
           if (!isServico) ajustes.codigo_local_estoque = Number(ALMOX_LOCAL_PADRAO);
           if (cUnidadeFinal) ajustes.cUnidade = cUnidadeFinal;
           if (cfopServicoEntrada || cfopCalculado) ajustes.cCFOPEntrada = cfopServicoEntrada || cfopCalculado;
-          // nQtde: inclui o valor digitado pelo user (medição física pode diferir da conversão Omie).
-          // Se a Omie rejeitar o campo, o Passo 3 faz retry sem ele (ver abaixo).
-          if (!isServico && Number.isFinite(nQtdeOverride) && nQtdeOverride > 0) ajustes.nQtde = nQtdeOverride;
 
           // Só incluir o item se tiver ajustes
           if (Object.keys(ajustes).length === 0) return null;
 
-          return {
+          // nQtde fica na raiz do item (não em itensAjustes — Omie rejeita lá)
+          const itemAEditar = {
             itensIde: { nSequencia: nSeq, cAcao: 'EDITAR' },
             itensAjustes: ajustes
           };
+          if (!isServico && Number.isFinite(nQtdeOverride) && nQtdeOverride > 0) {
+            itemAEditar.nQtde = nQtdeOverride;
+          }
+          return itemAEditar;
         }).filter(Boolean);
 
         recebimentoCache = recebAtual;
@@ -31723,10 +31726,10 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
         if (hasQtdeOverride) {
           // Retry sem nQtde: garante que armazém e unidade sejam aplicados mesmo se Omie rejeitar nQtde
           console.warn('[Compras/NFeAssociarPedido] Passo 3 com nQtde falhou, retrying sem nQtde:', errEstoque?.message);
-          const itensSemQtde = itensEditarEstoque.map(it => ({
-            ...it,
-            itensAjustes: Object.fromEntries(Object.entries(it.itensAjustes).filter(([k]) => k !== 'nQtde'))
-          }));
+          const itensSemQtde = itensEditarEstoque.map(it => {
+            const { nQtde: _qtde, ...semQtde } = it;
+            return semQtde;
+          });
           try {
             await chamarApiRecebimentoNfeOmieComRetryRedundant('AlterarRecebimento', {
               ide: { nIdReceb: Number(plano.n_id_receb) },

--- a/server.js
+++ b/server.js
@@ -30826,6 +30826,16 @@ function calcularScoreAssociacaoNfePedido(itemReceb, itemPedido) {
     }
   }
 
+  // Valor total: reforça match quando valores são iguais/próximos; penaliza divergência >30%
+  const valorRec = Number(itensCabec?.vTotalItem ?? null);
+  const valorPedido = Number(itemPedido?.n_val_tot ?? null);
+  if (Number.isFinite(valorRec) && Number.isFinite(valorPedido) && valorRec > 0 && valorPedido > 0) {
+    const diffPct = Math.abs(valorRec - valorPedido) / Math.max(valorRec, valorPedido);
+    if (diffPct < 0.001) score += 80;
+    else if (diffPct < 0.05) score += 40;
+    else if (diffPct > 0.30) score -= 40;
+  }
+
   return score;
 }
 
@@ -30942,7 +30952,25 @@ async function montarPlanoAssociacaoNfePedido(numeroNfe, numeroPedido, chaveNfe 
 
   const previewItens = [];
 
-  const itensRecebimentoEditar = itensReceb.map((item, idx) => {
+  // Sorted-greedy: pré-calcula o melhor score possível de cada item da NF e processa
+  // em ordem de confiança decrescente, evitando que itens com match fraco "roubem"
+  // itens do pedido de itens com match forte que aparecem depois na sequência da NF.
+  const melhoresScoresPossiveis = itensReceb.map((item) => {
+    let melhor = 0;
+    for (const pedItem of itensPedido) {
+      const s = calcularScoreAssociacaoNfePedido(item, pedItem);
+      if (s > melhor) melhor = s;
+    }
+    return melhor;
+  });
+  const ordemProcessamento = itensReceb
+    .map((_, idx) => idx)
+    .sort((a, b) => melhoresScoresPossiveis[b] - melhoresScoresPossiveis[a]);
+
+  const resultadosPorIdx = new Array(itensReceb.length);
+
+  for (const idx of ordemProcessamento) {
+    const item = itensReceb[idx];
     const itensCabec = item?.itensCabec || {};
     const itensInfoAdic = item?.itensInfoAdic || {};
     const nSequencia = Number(itensCabec?.nSequencia || idx + 1);
@@ -31033,29 +31061,34 @@ async function montarPlanoAssociacaoNfePedido(numeroNfe, numeroPedido, chaveNfe 
       itensIde.nIdItPedidoExistente = nCodItem;
     }
 
-    previewItens.push({
-      n_sequencia: itensIde.nSequencia,
-      nf_codigo_produto: codigoProdutoRec || null,
-      nf_descricao_produto: descricaoProdutoRec || null,
-      nf_qtde: itensCabec?.nQtdeNFe ?? null,
-      nf_unidade: String(itensCabec?.cUnidadeNfe || '').trim() || null,
-      nf_valor_total: itensCabec?.vTotalItem ?? null,
-      nf_cfop: cfopNf || null,
-      item_servico: servicoCfop.servico,
-      servico_cfop_entrada: servicoCfop.cfopEntrada,
-      pedido_item_encontrado: !!itemPedidoVinculo || servicoCfop.servico,
-      pedido_n_cod_item: Number.isFinite(nCodItem) && nCodItem > 0 ? nCodItem : null,
-      pedido_codigo_produto: String(itemPedidoVinculo?.c_produto || '').trim() || null,
-      pedido_descricao_produto: String(itemPedidoVinculo?.c_descricao || '').trim() || null,
-      pedido_qtde: itemPedidoVinculo?.n_qtde ?? null,
-      pedido_unidade: String(itemPedidoVinculo?.c_unidade || '').trim() || null,
-      pedido_valor_total: itemPedidoVinculo?.n_val_tot ?? null,
-      criterio_match: criterioMatch,
-      score_match: scoreMatch
-    });
+    resultadosPorIdx[idx] = {
+      itensIde,
+      previewItem: {
+        n_sequencia: itensIde.nSequencia,
+        nf_codigo_produto: codigoProdutoRec || null,
+        nf_descricao_produto: descricaoProdutoRec || null,
+        nf_qtde: itensCabec?.nQtdeNFe ?? null,
+        nf_unidade: String(itensCabec?.cUnidadeNfe || '').trim() || null,
+        nf_valor_total: itensCabec?.vTotalItem ?? null,
+        nf_cfop: cfopNf || null,
+        item_servico: servicoCfop.servico,
+        servico_cfop_entrada: servicoCfop.cfopEntrada,
+        pedido_item_encontrado: !!itemPedidoVinculo || servicoCfop.servico,
+        pedido_n_cod_item: Number.isFinite(nCodItem) && nCodItem > 0 ? nCodItem : null,
+        pedido_codigo_produto: String(itemPedidoVinculo?.c_produto || '').trim() || null,
+        pedido_descricao_produto: String(itemPedidoVinculo?.c_descricao || '').trim() || null,
+        pedido_qtde: itemPedidoVinculo?.n_qtde ?? null,
+        pedido_unidade: String(itemPedidoVinculo?.c_unidade || '').trim() || null,
+        pedido_valor_total: itemPedidoVinculo?.n_val_tot ?? null,
+        criterio_match: criterioMatch,
+        score_match: scoreMatch
+      }
+    };
+  }
 
-    return { itensIde };
-  });
+  // Reconstrói arrays na ordem original da NF-e
+  const itensRecebimentoEditar = resultadosPorIdx.map((r) => ({ itensIde: r.itensIde }));
+  for (const r of resultadosPorIdx) previewItens.push(r.previewItem);
 
   const itensPedidoInformativos = itensPedido
     .filter(itemPedidoDisponivel)

--- a/server.js
+++ b/server.js
@@ -31624,8 +31624,6 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
           const isServico = !!(previewItem?.item_servico);
           const cfopServicoEntrada = isServico ? previewItem?.servico_cfop_entrada : null;
 
-          const nQtdeOverride = Number(override?.nQtde || 0);
-
           const ajustes = {};
           if (!isServico) ajustes.codigo_local_estoque = Number(ALMOX_LOCAL_PADRAO);
           if (cUnidadeFinal) ajustes.cUnidade = cUnidadeFinal;
@@ -31634,15 +31632,10 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
           // Só incluir o item se tiver ajustes
           if (Object.keys(ajustes).length === 0) return null;
 
-          // nQtde fica na raiz do item (não em itensAjustes — Omie rejeita lá)
-          const itemAEditar = {
+          return {
             itensIde: { nSequencia: nSeq, cAcao: 'EDITAR' },
             itensAjustes: ajustes
           };
-          if (!isServico && Number.isFinite(nQtdeOverride) && nQtdeOverride > 0) {
-            itemAEditar.nQtde = nQtdeOverride;
-          }
-          return itemAEditar;
         }).filter(Boolean);
 
         recebimentoCache = recebAtual;
@@ -31705,43 +31698,24 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
       }
     }
 
-    // ─── Passo 3: EDITAR itens com codigo_local_estoque + cUnidade + nQtde (se override) ───
-    // nQtde é enviado junto para evitar que um EDITAR separado sem os outros campos reverta
-    // o armazém/unidade. Se a Omie rejeitar o payload com nQtde, faz retry sem ele.
+    // ─── Passo 3: EDITAR itens com codigo_local_estoque + cUnidade + cCFOPEntrada ───
+    // Define armazém (Recebimento) e unidade conforme o pedido.
+    // A Omie não suporta alterar nQtde via AlterarRecebimento — a qtd é calculada pela Omie.
     if (itensEditarEstoque && itensEditarEstoque.length > 0) {
-      const hasQtdeOverride = itensEditarEstoque.some(it => it.nQtde != null);
       try {
         const payloadEstoque = {
           ide: { nIdReceb: Number(plano.n_id_receb) },
           itensRecebimentoEditar: itensEditarEstoque
         };
-        console.log('[Compras/NFeAssociarPedido] ===== PASSO 3: estoque' + (hasQtdeOverride ? ' + nQtde' : '') + ' =====');
+        console.log('[Compras/NFeAssociarPedido] ===== PASSO 3: estoque + unidade =====');
         console.log(JSON.stringify(payloadEstoque, null, 2));
         console.log('[Compras/NFeAssociarPedido] ===================================');
         await chamarApiRecebimentoNfeOmieComRetryRedundant('AlterarRecebimento', payloadEstoque, {
           tentativasMaximas: 2
         });
-        console.log('[Compras/NFeAssociarPedido] Local estoque/unidade' + (hasQtdeOverride ? '/nQtde' : '') + ' atualizados com sucesso.');
+        console.log('[Compras/NFeAssociarPedido] Local estoque/unidade atualizados com sucesso.');
       } catch (errEstoque) {
-        if (hasQtdeOverride) {
-          // Retry sem nQtde: garante que armazém e unidade sejam aplicados mesmo se Omie rejeitar nQtde
-          console.warn('[Compras/NFeAssociarPedido] Passo 3 com nQtde falhou, retrying sem nQtde:', errEstoque?.message);
-          const itensSemQtde = itensEditarEstoque.map(it => {
-            const { nQtde: _qtde, ...semQtde } = it;
-            return semQtde;
-          });
-          try {
-            await chamarApiRecebimentoNfeOmieComRetryRedundant('AlterarRecebimento', {
-              ide: { nIdReceb: Number(plano.n_id_receb) },
-              itensRecebimentoEditar: itensSemQtde
-            }, { tentativasMaximas: 2 });
-            console.log('[Compras/NFeAssociarPedido] Passo 3 (sem nQtde) aplicado com sucesso.');
-          } catch (errFallback) {
-            console.warn('[Compras/NFeAssociarPedido] Falha ao atualizar local estoque:', errFallback?.message);
-          }
-        } else {
-          console.warn('[Compras/NFeAssociarPedido] Falha ao atualizar local estoque:', errEstoque?.message);
-        }
+        console.warn('[Compras/NFeAssociarPedido] Falha ao atualizar local estoque:', errEstoque?.message);
       }
     }
 


### PR DESCRIPTION
## O que mudou

Corrige o bug de 'roubo de item' no algoritmo de matching de itens NF-e x pedido de compra.

### Problema
O loop sequencial processava os itens da NF-e em ordem de sequência. Um item com match fraco (ex: CHAVE CANHÃO 7MM, score ~92) aparecia antes na NF e reservava o item do pedido 'CHAVE CANHÃO 8MM', deixando o item com match forte (CHAVE CANHÃO 8MM, score ~273) sem o item correto do pedido.

### Solução

**1. Sorted-greedy em \montarPlanoAssociacaoNfePedido\:**
- Pré-calcula o melhor score possível de cada item da NF contra todos os itens do pedido
- Ordena e processa em ordem de confiança decrescente (maior score primeiro)
- Reconstrói os arrays na ordem original da NF-e ao final

**2. Scoring por valor total em \calcularScoreAssociacaoNfePedido\:**
- +80 se valores idênticos (diferença < 0.1%)
- +40 se próximos (diferença < 5%)
- -40 se divergentes (diferença > 30%)

### Arquivos alterados
- \server.js\ — funções \calcularScoreAssociacaoNfePedido\ e \montarPlanoAssociacaoNfePedido\

### Como validar
Preview de NF-e com itens de descrição similar mas dimensões diferentes (ex: 7MM vs 8MM) — cada item da NF deve parear com o item de pedido de mesma especificação.