### PR TITLE
fix(recebimento): sempre enviar codigo_local_estoque=#D Recebimento na NF-e

### DIFF
--- a/server.js
+++ b/server.js
@@ -31396,7 +31396,7 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
     //   • nIdConta = nCodCC do pedido
     //   • cUnidade e nQtde do pedido (ou override do usuário) em cada item
     //   • dVencimento dinâmico conforme compras.contas_omie (tipo CR, melhor_data, fechamento_conta)
-    //   • Se conta especial (GLP/Frigelar): codigo_local_estoque = ESTOQUE_LOCAL_ESPECIAL
+    //   • codigo_local_estoque = #D Recebimento (10408201806) em todos os itens
     const CONTAS_ESPECIAIS = [10507452702, 10440916421];
     const ESTOQUE_LOCAL_ESPECIAL = 10408201806;
     let nCodCC = null;
@@ -31723,7 +31723,7 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
           const cUnidadeFinal = override?.cUnidade || cUnidadePedido || null;
 
           const ajustes = {};
-          if (aplicarEstoqueEspecial) ajustes.codigo_local_estoque = ESTOQUE_LOCAL_ESPECIAL;
+          ajustes.codigo_local_estoque = ESTOQUE_LOCAL_ESPECIAL; // sempre direciona para #D Recebimento
           if (cUnidadeFinal) ajustes.cUnidade = cUnidadeFinal;
           const previewItem = (plano?.itens_preview || []).find(p => p.n_sequencia === nSeq);
           const cfopServicoEntrada = previewItem?.item_servico ? previewItem?.servico_cfop_entrada : null;
@@ -31740,7 +31740,8 @@ app.post('/api/compras/pedidos-omie/nfe-associar-pedido', express.json(), async 
         }).filter(Boolean);
 
         recebimentoCache = recebAtual;
-        console.log(`[Compras/NFeAssociarPedido] nIdConta=${nCodCC} estoqueEspecial=${aplicarEstoqueEspecial} dVencimento=${dVencimento} parcelas=${parcelasLista.length} itensEditar=${itensEditarEstoque.length} overrides=${overrideMap.size}`);
+        console.log(`[Compras/NFeAssociarPedido] nIdConta=${nCodCC} localEstoqueRecebimento=${ESTOQUE_LOCAL_ESPECIAL} dVencimento=${dVencimento} parcelas=${parcelasLista.length} itensEditar=${itensEditarEstoque.length} overrides=${overrideMap.size}`);
+
       } catch (errPrep) {
         console.warn('[Compras/NFeAssociarPedido] Falha ao preparar dados de associação:', errPrep?.message);
       }


### PR DESCRIPTION
## O que mudou
Removida a condição `aplicarEstoqueEspecial` no Passo 3 da NF-e (editar itens no recebimento).

**Antes:** `codigo_local_estoque` só era enviado para contas especiais (GLP/Frigelar — IDs 10507452702 e 10440916421).
Para todas as outras contas o campo ficava em branco, e a Omie defaultava para **EXPEDIÇÃO**.

**Depois:** `codigo_local_estoque = 10408201806` (#D Recebimento) é sempre enviado em todos os itens, independente da conta financeira do pedido.

## Por que
Produtos recebidos pela aba Recebimento estavam entrando no estoque de EXPEDIÇÃO em vez de RECEBIMENTO no Omie.

## Como validar
1. Abrir a aba Recebimento no Intranet
2. Receber uma NF-e por uma conta normal (não GLP/Frigelar)
3. Conferir no Omie que o local de estoque dos itens ficou como **#D Recebimento** (não EXPEDIÇÃO)

## Arquivos alterados
- `server.js` — linha ~31726: removida condição `if (aplicarEstoqueEspecial)` antes de `ajustes.codigo_local_estoque`
