### PR TITLE
fix(ajustes): usar motivo válido na Omie

### DIFF
--- a/routes/ajustes.js
+++ b/routes/ajustes.js
@@ -18,6 +18,7 @@ const STATUS_EXECUTADO  = 'Executado';
 const STATUS_REPROVADO  = 'Reprovado';
 
 const TIPOS_VALIDOS = new Set(['ENT', 'SAI']);
+const MOTIVOS_OMIE_VALIDOS = new Set(['INV', 'OPS', 'PER', 'PDV']);
 
 let schemaAjustesOk = false;
 
@@ -192,7 +193,8 @@ async function incluirAjusteOmie(registro, aprovadoPor) {
 
   const dataObj = normalizarDataMovimentacao(data_movimentacao);
   const tipoOmie = String(tipo_operacao || '').toUpperCase();
-  const motivoOmie = String(motivo || 'AJU').toUpperCase();
+  const motivoNormalizado = String(motivo || 'INV').toUpperCase();
+  const motivoOmie = MOTIVOS_OMIE_VALIDOS.has(motivoNormalizado) ? motivoNormalizado : 'INV';
   const obsTexto = obs
     ? String(obs).slice(0, 200)
     : `Ajuste ${tipoOmie} #${id} - Produto ${codigo || ''}. Executado por ${aprovadoPor}.`;
@@ -506,7 +508,8 @@ router.post('/', express.json(), async (req, res) => {
     const dataMovSql     = formatarDataSql(dataMovObj);
     const solicitante    = String(req.body?.solicitante || '').trim() || null;
     const obs            = String(req.body?.obs || '').trim() || null;
-    const motivo         = String(req.body?.motivo || 'AJU').trim().toUpperCase() || 'AJU';
+    const motivoRaw      = String(req.body?.motivo || 'INV').trim().toUpperCase() || 'INV';
+    const motivo         = MOTIVOS_OMIE_VALIDOS.has(motivoRaw) ? motivoRaw : 'INV';
     const itens          = Array.isArray(req.body?.itens) ? req.body.itens : [];
 
     if (!TIPOS_VALIDOS.has(tipo_operacao)) {


### PR DESCRIPTION
## O que mudou
- normaliza o campo `motivo` dos ajustes para apenas valores aceitos pela API de ajuste de estoque da Omie
- troca o fallback de `AJU` para `INV` no fluxo de criação e aprovação de ajustes
- evita que ajustes pendentes de inventário travem na aprovação por `motivo` inválido

## Por que
A API `https://app.omie.com.br/api/v1/estoque/ajuste/` rejeita `motivo=AJU`. O valor `AJU` é válido para `origem`, mas não para `motivo`. Isso estava prendendo a aprovação em massa dos ajustes no primeiro item.

## Como validar
- criar ou reutilizar um ajuste pendente com `tipo_operacao` `ENT` ou `SAI`
- aprovar o ajuste pela tela `Solicitação de ajuste`
- confirmar que a Omie não retorna mais erro de `preenchimento inválido da tag [motivo]`
- conferir no banco que o registro muda de `Aguardando aprovacao` para `Executado` após aprovação bem-sucedida

## Arquivos alterados
- `routes/ajustes.js`