### PR TITLE
fix(logistica): listar todos os pendentes de ajustes e transferencias

### DIFF
--- a/routes/ajustes.js
+++ b/routes/ajustes.js
@@ -18,6 +18,13 @@ const STATUS_EXECUTADO  = 'Executado';
 const STATUS_REPROVADO  = 'Reprovado';
 
 const TIPOS_VALIDOS = new Set(['ENT', 'SAI']);
+const MOTIVOS_OMIE_VALIDOS = new Set(['INV', 'OPS', 'PER', 'PDV']);
+const ERROS_OMIE_NAO_RETRYAVEIS = [
+  /valor unit.rio.+deve ser maior que zero/i,
+  /preenchimento inv.lido da tag\s*\[motivo\]/i,
+  /nenhum produto foi localizado/i,
+  /produto.+n.o encontrado/i
+];
 
 let schemaAjustesOk = false;
 
@@ -154,6 +161,9 @@ function sleep(ms) {
 
 function isErroOmieRetryable({ httpStatus, texto }) {
   const body = String(texto || '');
+  if (ERROS_OMIE_NAO_RETRYAVEIS.some((regex) => regex.test(body))) {
+    return false;
+  }
   return httpStatus === 425
     || httpStatus === 429
     || httpStatus >= 500
@@ -472,18 +482,41 @@ router.post('/reconciliar', express.json(), async (req, res) => {
   }
 });
 
-// GET /api/ajustes — lista últimos 500 ajustes
+// GET /api/ajustes — lista todos os pendentes + histórico recente
 router.get('/', async (_req, res) => {
   try {
     await ensureAjustesSchema();
     const { rows } = await dbQuery(
-      `SELECT id, tipo_operacao, codigo_produto, codigo, descricao, qtd,
+      `WITH pendentes AS (
+         SELECT id, tipo_operacao, codigo_produto, codigo, descricao, qtd,
+                local_estoque, local_nome, data_movimentacao, cmc, motivo, obs,
+                solicitante, status, aprovado_por, aprovado_em,
+                reprovado_por, reprovado_em, motivo_reprovacao, criado_em,
+                0 AS ordem_status
+           FROM mensagens.ajustes_estoque
+          WHERE lower(coalesce(status, '')) NOT IN ('executado', 'reprovado')
+       ),
+       historico AS (
+         SELECT id, tipo_operacao, codigo_produto, codigo, descricao, qtd,
+                local_estoque, local_nome, data_movimentacao, cmc, motivo, obs,
+                solicitante, status, aprovado_por, aprovado_em,
+                reprovado_por, reprovado_em, motivo_reprovacao, criado_em,
+                1 AS ordem_status
+           FROM mensagens.ajustes_estoque
+          WHERE lower(coalesce(status, '')) IN ('executado', 'reprovado')
+          ORDER BY id DESC
+          LIMIT 250
+       )
+       SELECT id, tipo_operacao, codigo_produto, codigo, descricao, qtd,
               local_estoque, local_nome, data_movimentacao, cmc, motivo, obs,
               solicitante, status, aprovado_por, aprovado_em,
               reprovado_por, reprovado_em, motivo_reprovacao, criado_em
-         FROM mensagens.ajustes_estoque
-        ORDER BY id DESC
-        LIMIT 500`
+         FROM (
+           SELECT * FROM pendentes
+           UNION ALL
+           SELECT * FROM historico
+         ) itens
+        ORDER BY ordem_status, id DESC`
     );
     res.json({ ok: true, registros: rows });
   } catch (err) {

--- a/routes/transferencias.js
+++ b/routes/transferencias.js
@@ -344,7 +344,49 @@ router.get('/', async (_req, res) => {
   try {
     await ensureTransferenciasSchema();
     const { rows } = await dbQuery(
-      `SELECT id,
+      `WITH pendentes AS (
+         SELECT id,
+                codigo_produto,
+                codigo,
+                descricao,
+                qtd,
+                origem,
+                destino,
+                data_movimentacao,
+                cmc,
+                solicitante,
+                status,
+                aprovado_pro,
+                reprovado_por,
+                reprovado_em,
+                motivo_reprovacao,
+                0 AS ordem_status
+           FROM mensagens.transferencias
+          WHERE lower(coalesce(status, '')) NOT IN ('transferido', 'reprovado')
+       ),
+       historico AS (
+         SELECT id,
+                codigo_produto,
+                codigo,
+                descricao,
+                qtd,
+                origem,
+                destino,
+                data_movimentacao,
+                cmc,
+                solicitante,
+                status,
+                aprovado_pro,
+                reprovado_por,
+                reprovado_em,
+                motivo_reprovacao,
+                1 AS ordem_status
+           FROM mensagens.transferencias
+          WHERE lower(coalesce(status, '')) IN ('transferido', 'reprovado')
+          ORDER BY id DESC
+          LIMIT 250
+       )
+       SELECT id,
               codigo_produto,
               codigo,
               descricao,
@@ -359,9 +401,12 @@ router.get('/', async (_req, res) => {
               reprovado_por,
               reprovado_em,
               motivo_reprovacao
-         FROM mensagens.transferencias
-        ORDER BY id DESC
-        LIMIT 250`
+         FROM (
+           SELECT * FROM pendentes
+           UNION ALL
+           SELECT * FROM historico
+         ) itens
+        ORDER BY ordem_status, id DESC`
     );
 
     res.json({ ok: true, registros: rows });


### PR DESCRIPTION
## O que mudou\n- faz a listagem de transferencias trazer todos os pendentes e limitar apenas o historico recente\n- faz a listagem de ajustes trazer todos os pendentes e limitar apenas o historico recente\n- preserva o tratamento de erro permanente da Omie nos ajustes para nao retryar validacoes definitivas\n\n## Por que\n- transferencias e ajustes podiam sumir da tela quando havia mais registros pendentes do que o corte fixo da listagem\n- isso atrapalhava a aprovacao em massa do fechamento de estoque\n\n## Como validar\n- criar ou manter mais de 250 transferencias pendentes e confirmar que todas aparecem antes do historico\n- criar ou manter mais de 500 ajustes pendentes e confirmar que todos aparecem antes do historico\n- confirmar que historico continua aparecendo apos os pendentes\n\n## Arquivos alterados\n- routes/transferencias.js\n- routes/ajustes.js