### PR TITLE
fix(omie): interromper lote em bloqueios e erros permanentes

### DIFF
--- a/menu_produto.js
+++ b/menu_produto.js
@@ -19681,6 +19681,16 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // Ajuste approve-all button
   const ajusteApproveAllBtn = document.getElementById('solicitacoesAjusteApproveAll');
+  const omieBatchStopRegexes = [
+    /api bloqueada por consumo indevido/i,
+    /consumo redundante detectado/i,
+    /nenhum produto foi localizado/i,
+    /produto.+n.o encontrado/i,
+    /valor unit.rio.+deve ser maior que zero/i
+  ];
+  const shouldStopOmieApprovalBatch = (mensagem) => omieBatchStopRegexes.some((regex) => regex.test(String(mensagem || '')));
+  const waitNextOmieBatchItem = (ms = 900) => new Promise(resolve => setTimeout(resolve, ms));
+
   if (ajusteApproveAllBtn && !ajusteApproveAllBtn.__ajusteBound) {
     ajusteApproveAllBtn.__ajusteBound = true;
     ajusteApproveAllBtn.addEventListener('click', async () => {
@@ -19695,6 +19705,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       ajusteApproveAllBtn.disabled = true;
       const originalLabel = ajusteApproveAllBtn.textContent;
       const erros = [];
+      let loteInterrompido = false;
       let aprovados = 0;
       for (const a of pendentes) {
         aprovados++;
@@ -19702,14 +19713,30 @@ document.addEventListener('DOMContentLoaded', async () => {
         try {
           const resp = await fetch(`/api/ajustes/${a.id}/aprovar`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ aprovadoPor: usuario }) });
           const json = await resp.json().catch(() => ({}));
-          if (!resp.ok || !json?.ok) erros.push(`ID ${a.id}: ${json?.error || 'Erro'}`);
+          if (!resp.ok || !json?.ok) {
+            const mensagem = `ID ${a.id}: ${json?.error || 'Erro'}`;
+            erros.push(mensagem);
+            if (shouldStopOmieApprovalBatch(json?.error || mensagem)) {
+              loteInterrompido = true;
+              break;
+            }
+          }
         } catch (err) {
-          erros.push(`ID ${a.id}: ${err?.message || 'Erro de rede'}`);
+          const mensagem = `ID ${a.id}: ${err?.message || 'Erro de rede'}`;
+          erros.push(mensagem);
+          if (shouldStopOmieApprovalBatch(err?.message || mensagem)) {
+            loteInterrompido = true;
+            break;
+          }
+        }
+        if (aprovados < pendentes.length) {
+          await waitNextOmieBatchItem();
         }
       }
       ajusteApproveAllBtn.textContent = originalLabel;
       ajusteApproveAllBtn.disabled = false;
-      if (erros.length) alert(`Concluído com erros:\n${erros.join('\n')}`);
+      if (loteInterrompido) alert(`Processamento interrompido para evitar novo bloqueio da Omie.\n\nÚltimo erro:\n${erros[erros.length - 1] || 'Erro desconhecido'}`);
+      else if (erros.length) alert(`Concluído com erros:\n${erros.join('\n')}`);
       else alert('Todos os ajustes pendentes foram executados com sucesso!');
       await carregarSolicitacoesAjustes(true);
     });
@@ -19738,6 +19765,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       transferApproveAllBtn.disabled = true;
       const originalLabel = transferApproveAllBtn.textContent;
       const erros = [];
+      let loteInterrompido = false;
       let aprovados = 0;
       for (const t of pendentes) {
         aprovados++;
@@ -19749,14 +19777,30 @@ document.addEventListener('DOMContentLoaded', async () => {
             body: JSON.stringify({ aprovadoPor: usuario })
           });
           const json = await resp.json().catch(() => ({}));
-          if (!resp.ok || !json?.ok) erros.push(`ID ${t.id}: ${json?.error || 'Erro'}`);
+          if (!resp.ok || !json?.ok) {
+            const mensagem = `ID ${t.id}: ${json?.error || 'Erro'}`;
+            erros.push(mensagem);
+            if (shouldStopOmieApprovalBatch(json?.error || mensagem)) {
+              loteInterrompido = true;
+              break;
+            }
+          }
         } catch (err) {
-          erros.push(`ID ${t.id}: ${err?.message || 'Erro de rede'}`);
+          const mensagem = `ID ${t.id}: ${err?.message || 'Erro de rede'}`;
+          erros.push(mensagem);
+          if (shouldStopOmieApprovalBatch(err?.message || mensagem)) {
+            loteInterrompido = true;
+            break;
+          }
+        }
+        if (aprovados < pendentes.length) {
+          await waitNextOmieBatchItem();
         }
       }
       transferApproveAllBtn.textContent = originalLabel;
       transferApproveAllBtn.disabled = false;
-      if (erros.length) alert(`Concluído com erros:\n${erros.join('\n')}`);
+      if (loteInterrompido) alert(`Processamento interrompido para evitar novo bloqueio da Omie.\n\nÚltimo erro:\n${erros[erros.length - 1] || 'Erro desconhecido'}`);
+      else if (erros.length) alert(`Concluído com erros:\n${erros.join('\n')}`);
       else alert('Todas as transferências pendentes foram executadas com sucesso!');
       await carregarSolicitacoesTransferencias(true);
     });

--- a/routes/ajustes.js
+++ b/routes/ajustes.js
@@ -18,6 +18,15 @@ const STATUS_EXECUTADO  = 'Executado';
 const STATUS_REPROVADO  = 'Reprovado';
 
 const TIPOS_VALIDOS = new Set(['ENT', 'SAI']);
+const MOTIVOS_OMIE_VALIDOS = new Set(['INV', 'OPS', 'PER', 'PDV']);
+const ERROS_OMIE_NAO_RETRYAVEIS = [
+  /api bloqueada por consumo indevido/i,
+  /consumo redundante detectado/i,
+  /valor unit.rio.+deve ser maior que zero/i,
+  /preenchimento inv.lido da tag\s*\[motivo\]/i,
+  /nenhum produto foi localizado/i,
+  /produto.+n.o encontrado/i
+];
 
 let schemaAjustesOk = false;
 

--- a/routes/transferencias.js
+++ b/routes/transferencias.js
@@ -7,6 +7,13 @@ const { OMIE_APP_KEY, OMIE_APP_SECRET } = require('../config.server');
 const STATUS_AGUARDANDO = 'Aguardando aprovação';
 const STATUS_TRANSFERIDO = 'Transferido';
 const STATUS_REPROVADO = 'Reprovado';
+const ERROS_OMIE_SEM_RETRY_IMEDIATO = [
+  /api bloqueada por consumo indevido/i,
+  /consumo redundante detectado/i,
+  /nenhum produto foi localizado/i,
+  /produto.+n.o encontrado/i,
+  /valor unit.rio.+deve ser maior que zero/i
+];
 
 let schemaTransferenciasOk = false;
 
@@ -166,6 +173,9 @@ function sleep(ms) {
 
 function isErroOmieRetryable({ httpStatus, texto }) {
   const body = String(texto || '');
+  if (ERROS_OMIE_SEM_RETRY_IMEDIATO.some((regex) => regex.test(body))) {
+    return false;
+  }
   return httpStatus === 425
     || httpStatus === 429
     || httpStatus >= 500


### PR DESCRIPTION
## O que mudou
- interrompe o retry imediato nas rotas de ajustes e transferências quando a Omie retorna bloqueio por consumo indevido, consumo redundante ou erros permanentes como produto não localizado
- faz o botão de `Aprovar pendentes` parar o lote automaticamente ao encontrar esses erros, em vez de continuar martelando a API
- adiciona um pequeno intervalo entre aprovações em lote para reduzir a chance de bloqueio/redundância

## Por que
A Omie estava respondendo com bloqueios de consumo e consumo redundante, e o sistema continuava insistindo na mesma operação ou no restante do lote. Isso levava a bloqueios longos e tornava o fluxo inseguro.

## Como validar
1. abrir `Solicitação de transferência` ou `Solicitação de ajuste`
2. iniciar `Aprovar pendentes`
3. simular ou reproduzir um erro da Omie como `API bloqueada por consumo indevido`, `Consumo redundante detectado` ou `Nenhum produto foi localizado`
4. confirmar que o lote interrompe no primeiro erro crítico e exibe a mensagem de interrupção
5. confirmar que as rotas não fazem retry imediato nesses erros

## Arquivos alterados
- `menu_produto.js`
- `routes/ajustes.js`
- `routes/transferencias.js`